### PR TITLE
Fix small typo in one exemple of the User and Programming Guide

### DIFF
--- a/doc/guide/ClusterShell_UserGuide_EN.tex
+++ b/doc/guide/ClusterShell_UserGuide_EN.tex
@@ -1937,7 +1937,7 @@ task.shell("/bin/uname -r", nodes="green[36-39,133]")
 
 task.resume()
 
-print worker.node_buffer("green37")
+print task.node_buffer("green37")
 
 for buf, nodes in task.iter_buffers():
 	print nodes, buf


### PR DESCRIPTION
There was a small typo in the sequential remote command example of the _User and Programming Guide_.

Blind running the given example raised the following exception:

```
Traceback (most recent call last):
  File "example.py", line 12, in <module>
    print worker.node_buffer(node)
NameError: name 'worker' is not defined
```

Replacing `worker` by `task` obviously fix the issue.
