### PR TITLE
Allow usage of sshpass

### DIFF
--- a/lib/ClusterShell/Worker/Ssh.py
+++ b/lib/ClusterShell/Worker/Ssh.py
@@ -109,9 +109,6 @@ class ScpClient(CopyClient):
         if connect_timeout > 0:
             cmd_l.append("-oConnectTimeout=%d" % connect_timeout)
 
-        # Disable passphrase/password querying
-        cmd_l.append("-oBatchMode=yes")
-
         # Add custom scp options
         for opts in options:
             if opts:


### PR DESCRIPTION
Suggestion for enhancement for discussion:   Allow SSH password login

This class should then compose a command line like this: 
/usr/bin/sshpass -f ~/remotepasswordfile ssh -a -x -l root -oBatchMode=no -oConnectTimeout=15 -oBatchMode=yes -oStrictHostKeyChecking=no sysadm.local hostname

Part of the solution would be deleting this line:
``cmd_l.append("-oBatchMode=yes")``
(Is it really necessary?)

There is still another issue :
"""
DEBUG:root:clush: STARTING DEBUG
clush: nodeset=sysadm.local fanout=64 [timeout conn=10.0 cmd=0.0] command="hostname"
SSH: /usr/bin/sshpass -f ~/remotepasswordfile ssh -a -x -l root -oBatchMode=no -oConnectTimeout=15 -oBatchMode=yes -oStrictHostKeyChecking=no sysadm.local hostname
clush: sysadm.local: exited with exit code 255
"""
The above SSH command line works in a shell but not invoked by clush.