### PR TITLE
Support for sshpass authentification

### DIFF
--- a/conf/clush.conf
+++ b/conf/clush.conf
@@ -12,6 +12,16 @@ fd_max: 16384
 history_size: 100
 node_count: yes
 verbosity: 1
+
+# Add always all remote hosts to known_hosts without confirmation
 #ssh_user: root
 #ssh_path: /usr/bin/ssh
 #ssh_options: -oStrictHostKeyChecking=no
+
+# Non-interactivly performing password authentication with SSH's so called "interactive keyboard password authentication".
+#ssh_user: root
+#ssh_path: /usr/bin/sshpass -f /root/remotepasswordfile /usr/bin/ssh
+#scp_path: /usr/bin/sshpass -f /root/remotepasswordfile /usr/bin/scp
+#ssh_options: -oBatchMode=no -oStrictHostKeyChecking=no
+
+

--- a/lib/ClusterShell/CLI/Clush.py
+++ b/lib/ClusterShell/CLI/Clush.py
@@ -856,6 +856,10 @@ def main():
         task.set_info("ssh_path", config.ssh_path)
     if config.ssh_options:
         task.set_info("ssh_options", config.ssh_options)
+    if config.scp_path:
+        task.set_info("scp_path", config.scp_path)
+    if config.scp_options:
+        task.set_info("scp_options", config.scp_options)
     if config.rsh_path:
         task.set_info("rsh_path", config.rsh_path)
     if config.rcp_path:

--- a/lib/ClusterShell/CLI/Config.py
+++ b/lib/ClusterShell/CLI/Config.py
@@ -172,6 +172,16 @@ class ClushConfig(ConfigParser.ConfigParser, object):
         return self._get_optional("Main", "ssh_options")
 
     @property
+    def scp_path(self):
+        """scp_path value as a string (optional)"""
+        return self._get_optional("Main", "scp_path")
+
+    @property
+    def scp_options(self):
+        """scp_options value as a string (optional)"""
+        return self._get_optional("Main", "scp_options")
+
+    @property
     def rsh_path(self):
         """rsh_path value as a string (optional)"""
         return self._get_optional("Main", "rsh_path")


### PR DESCRIPTION
Non-interactivly performing password authentication with SSH's so called "interactive keyboard password authentication".

In order to use this feature the following options must be on command line or in
`/etc/clustershell/clush.conf`:

```
ssh_user: root
ssh_path: /usr/bin/sshpass -f /root/remotepasswordfile /usr/bin/ssh
scp_path: /usr/bin/sshpass -f /root/remotepasswordfile /usr/bin/scp
ssh_options: -oBatchMode=no -oStrictHostKeyChecking=no
```

In this example `/root/remotepasswordfile` is the file where the password belonging to the remote accounts for the ssh user `root` is stored.