### PR TITLE
Allow scp_options overwrite ssh_options

### DIFF
--- a/lib/ClusterShell/Worker/Ssh.py
+++ b/lib/ClusterShell/Worker/Ssh.py
@@ -94,7 +94,7 @@ class ScpClient(CopyClient):
         task = self.worker.task
         path = task.info("scp_path") or "scp"
         user = task.info("scp_user") or task.info("ssh_user")
-        options = [ task.info("ssh_options"), task.info("scp_options") ]
+        options = [ task.info("scp_options"), task.info("ssh_options") ]
 
         # Build scp command
         cmd_l = [ path ]


### PR DESCRIPTION
scp uses ssh_options _and_ scp_options by default. In some usecases scp needs slightly different options then ssh. This is why scp_options was introduced. scp_options needs to be sourced first, in order to allow changes to ssh_options.