### PR TITLE
Accept new options "ssh_path", "ssh_options", ... from commandline too....

### DIFF
--- a/lib/ClusterShell/CLI/Config.py
+++ b/lib/ClusterShell/CLI/Config.py
@@ -92,8 +92,14 @@ class ClushConfig(ConfigParser.ConfigParser, object):
             self._set_main("fanout", options.fanout)
         if options.user:
             self._set_main("ssh_user", options.user)
-        if options.options:
-            self._set_main("ssh_options", options.options)
+        if options.ssh_options:
+            self._set_main("ssh_options", options.ssh_options)
+        if options.ssh_path:
+            self._set_main("ssh_path", options.ssh_path)
+        if options.scp_options:
+            self._set_main("scp_options", options.scp_options)
+        if options.scp_path:
+            self._set_main("scp_path", options.scp_path)
         if options.connect_timeout:
             self._set_main("connect_timeout", options.connect_timeout)
         if options.command_timeout:

--- a/lib/ClusterShell/CLI/OptionParser.py
+++ b/lib/ClusterShell/CLI/OptionParser.py
@@ -202,8 +202,20 @@ class OptionParser(optparse.OptionParser):
                           help=optparse.SUPPRESS_HELP, type="float")
         optgrp.add_option("-l", "--user", action="store", type="safestring",
                           dest="user", help="execute remote command as user")
-        optgrp.add_option("-o", "--options", action="store", dest="options",
-                          help="can be used to give ssh options")
+        optgrp.add_option("-o", "--options", action="store", dest="ssh_options",
+                          help="set ssh options")
+        optgrp.add_option("--ssh_options", action="store",
+                          dest="ssh_options", help="set ssh " \
+                          "options, same as --options")
+        optgrp.add_option("--ssh_path", action="store",
+                          dest="ssh_path", help="set path to ssh, " \
+                          "can be used to prepend sshpass")
+        optgrp.add_option("--scp_options", action="store",
+                          dest="scp_options", help="set scp options", \
+                          type="float")
+        optgrp.add_option("--scp_path", action="store",
+                          dest="scp_path", help="set path to scp, " \
+                          "can be used to prepend sshpass")
         optgrp.add_option("-t", "--connect_timeout", action="store",
                           dest="connect_timeout", help="limit time to " \
                           "connect to a node" ,type="float")


### PR DESCRIPTION
... Closes #247.

.Test
`> clush --ssh_path='sshpass -p <MySecretPassword> ssh' --ssh_options='-oBatchMode=no -oStrictHostKeyChecking=no' -l <MyRemoteUser> -w <OtherHost> echo hallo`

This possibility is important because users will use sshpass usualy once in the beginning of a session to append their certificates to the remote authorized_hosts file. Once this is done sshpass is not needed any more as clush can connect the usual way (which is much faster). In order to not be forced to modify the configuration file just for this one and first connect, users should be enabled to pass --ssh_path, --scp_path, --ssh_options and --scp_options on the command line.

.Use case: Distribute and install ssh-keys
`> cat ~/.ssh/id_rsa.pub | clush --ssh_path='sshpass -p <MySecretPassword> ssh' --ssh_options='-oBatchMode=no -oStrictHostKeyChecking=no' -l <MyRemoteUser> -w <OtherHosts> -b 'cat - >>/home/<MyRemoteUser>/.ssh/authorized_keys'`