### PR TITLE
Task: add default event handler in task.shell()

### DIFF
--- a/lib/ClusterShell/Task.py
+++ b/lib/ClusterShell/Task.py
@@ -577,7 +577,7 @@ class Task(object):
         >>> task.resume()
         """
 
-        handler = kwargs.get("handler", None)
+        handler = kwargs.get("handler", EventHandler())
         timeo = kwargs.get("timeout", None)
         autoclose = kwargs.get("autoclose", False)
         stderr = kwargs.get("stderr", self.default("stderr"))


### PR DESCRIPTION
Fixed the bug I ran into as detailed in this [thread](http://sourceforge.net/p/clustershell/mailman/clustershell-devel/thread/CAMD27Oi836s4Y8vQn6A3sSzrFipzasHhQ-hOw28hSJ26knCAgA%40mail.gmail.com/#msg34136205) from the mailing list.