### PR TITLE
Engine: declared bracket symbols as attributes of the ParsingEngine

### DIFF
--- a/lib/ClusterShell/NodeSet.py
+++ b/lib/ClusterShell/NodeSet.py
@@ -717,6 +717,9 @@ class ParsingEngine(object):
                  'intersection_update': '&',
                  'symmetric_difference_update': '^' }
 
+    BRACKET_OPEN = '['
+    BRACKET_CLOSE = ']'
+
     def __init__(self, group_resolver):
         """
         Initialize Parsing Engine.
@@ -914,7 +917,7 @@ class ParsingEngine(object):
             op_code = next_op_code
 
             op_idx, next_op_code = self._next_op(pat)
-            bracket_idx = pat.find('[')
+            bracket_idx = pat.find(self.BRACKET_OPEN)
 
             # Check if the operator is after the bracket, or if there
             # is no operator at all but some brackets.
@@ -926,19 +929,19 @@ class ParsingEngine(object):
                 newpat = ""
                 sfx = pat
                 while bracket_idx >= 0 and (op_idx > bracket_idx or op_idx < 0):
-                    pfx, sfx = sfx.split('[', 1)
+                    pfx, sfx = sfx.split(self.BRACKET_OPEN, 1)
                     try:
-                        rng, sfx = sfx.split(']', 1)
+                        rng, sfx = sfx.split(self.BRACKET_CLOSE, 1)
                     except ValueError:
                         raise NodeSetParseError(pat, "missing bracket")
 
                     # illegal closing bracket checks
-                    if pfx.find(']') > -1:
+                    if pfx.find(self.BRACKET_CLOSE) > -1:
                         raise NodeSetParseError(pfx, "illegal closing bracket")
 
                     if len(sfx) > 0:
-                        bra_end = sfx.find(']')
-                        bra_start = sfx.find('[')
+                        bra_end = sfx.find(self.BRACKET_CLOSE)
+                        bra_start = sfx.find(self.BRACKET_OPEN)
                         if bra_start == -1:
                             bra_start = bra_end + 1
                         if bra_end >= 0 and bra_end < bra_start:
@@ -959,7 +962,8 @@ class ParsingEngine(object):
                         rsets += pfxrvec
 
                     # readahead for sanity check
-                    bracket_idx = sfx.find('[', bracket_idx - pfxlen)
+                    bracket_idx = sfx.find(self.BRACKET_OPEN,
+                                           bracket_idx - pfxlen)
                     op_idx, next_op_code = self._next_op(sfx)
 
                     # Check for empty component or sequenced ranges
@@ -1015,7 +1019,7 @@ class ParsingEngine(object):
                         raise NodeSetParseError(node or pat, msg)
 
                 # Check for illegal closing bracket
-                if node.find(']') > -1:
+                if node.find(self.BRACKET_CLOSE) > -1:
                     raise NodeSetParseError(node, "illegal closing bracket")
 
                 newpat, rsets = self._scan_string_single(node, autostep)


### PR DESCRIPTION
Needed to easily change the patterns ClusterShell.NodeSet parses and
thus use it in pre-existing project where usual patterns are already
meaningful.