### PR TITLE
Prevent padding groups errors

### DIFF
--- a/lib/ClusterShell/NodeSet.py
+++ b/lib/ClusterShell/NodeSet.py
@@ -778,7 +778,7 @@ class ParsingEngine(object):
         Initialize Parsing Engine.
         """
         self.group_resolver = group_resolver
-        self.base_node_re = re.compile("(\D*)(\d*)")
+        self.base_node_re = re.compile("([^1-9]*)(\d*)")
 
     def parse(self, nsobj, autostep):
         """


### PR DESCRIPTION
Grouping similar nodes with different 0 padding leads to error.

Before this patch:
server1 server2 server03 are grouped to server\[01-03\] (what is wrong)

After this patch:
server1 server2 server03 are grouped to server[1-2],server03