### PR TITLE
manpage: Fix typo additonal -> additional

### DIFF
--- a/doc/man/man1/clubak.1
+++ b/doc/man/man1/clubak.1
@@ -37,7 +37,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .sp
 \fBclubak\fP formats text from standard input containing lines of the form
 "\fInode:output\fP".  It is fully backward compatible with \fBdshbak\fP(1) but
-provides additonal features. For instance, \fBclubak\fP always displays
+provides additional features. For instance, \fBclubak\fP always displays
 its results sorted by node/nodeset.
 .sp
 You do not need to use \fBclubak\fP when using \fBclush\fP(1) as all output

--- a/doc/sphinx/tools/clubak.rst
+++ b/doc/sphinx/tools/clubak.rst
@@ -36,7 +36,7 @@ Or with ``-L`` display option to disable header block::
 
 Indeed, *clubak* formats text from standard input containing lines of the form
 *node: output*.  It is fully backward compatible with *dshbak(1)* available
-with *pdsh* but provides additonal features. For instance, *clubak* always
+with *pdsh* but provides additional features. For instance, *clubak* always
 displays its results sorted by node/nodeset.
 
 But you do not need to execute *clubak* when using *clush* as all output

--- a/doc/txt/clubak.txt
+++ b/doc/txt/clubak.txt
@@ -23,7 +23,7 @@ DESCRIPTION
 ===========
 ``clubak`` formats text from standard input containing lines of the form
 "`node:output`".  It is fully backward compatible with ``dshbak``\(1) but
-provides additonal features. For instance, ``clubak`` always displays
+provides additional features. For instance, ``clubak`` always displays
 its results sorted by node/nodeset.
 
 You do not need to use ``clubak`` when using ``clush``\(1) as all output


### PR DESCRIPTION
Debian lintian tool is complaining :

  spelling-error-in-manpage
    usr/share/man/man1/clubak.1.gz additonal additional