### PR TITLE
EnginePoll/EngineEpoll: fix polling timeout

### DIFF
--- a/lib/ClusterShell/Engine/EPoll.py
+++ b/lib/ClusterShell/Engine/EPoll.py
@@ -114,7 +114,12 @@ class EngineEPoll(Engine):
                     timeo = timeout
 
                 self._current_loopcnt += 1
-                evlist = self.epolling.poll(timeo + 0.001)
+
+                if timeo < 0:
+                    poll_timeo = -1
+                else:
+                    poll_timeo = timeo
+                evlist = self.epolling.poll(poll_timeo)
 
             except IOError as ex:
                 # might get interrupted by a signal

--- a/lib/ClusterShell/Engine/Poll.py
+++ b/lib/ClusterShell/Engine/Poll.py
@@ -109,7 +109,12 @@ class EnginePoll(Engine):
                     timeo = timeout
 
                 self._current_loopcnt += 1
-                evlist = self.polling.poll(timeo * 1000.0 + 1.0)
+
+                if timeo < 0:
+                    poll_timeo = -1
+                else:
+                    poll_timeo = timeo * 1000.0
+                evlist = self.polling.poll(poll_timeo)
 
             except select.error as ex:
                 # might get interrupted by a signal


### PR DESCRIPTION
Force the timeout to be exactly `-1` when is negative. The implementation
of the `poll()` system call in some OSes, including macOS and BSDs, throws
an error for arbitrary negative values different from `-1`.

Fix #353