### PR TITLE
Added configuration section for section slurmuser,su

### DIFF
--- a/conf/groups.conf.d/slurm.conf.example
+++ b/conf/groups.conf.d/slurm.conf.example
@@ -30,3 +30,12 @@ map: squeue -h -j $GROUP -o "%N"
 list: squeue -h -o "%i" -t R
 reverse: squeue -h -w $NODE -o "%i"
 cache_time: 60
+
+#
+# SLURM user bindings for running jobs
+#
+[slurmuser,su]
+map: squeue -h -u $GROUP -o "%N" -t running
+list: squeue -h -o "%i" -t R
+reverse: squeue -h -w $NODE -o "%i"
+cache_time: 60

--- a/conf/groups.conf.d/slurm.conf.example
+++ b/conf/groups.conf.d/slurm.conf.example
@@ -35,7 +35,7 @@ cache_time: 60
 # SLURM user bindings for running jobs
 #
 [slurmuser,su]
-map: squeue -h -u $GROUP -o "%N" -t running
+map: squeue -h -u $GROUP -o "%N" -t R
 list: squeue -h -o "%i" -t R
 reverse: squeue -h -w $NODE -o "%i"
 cache_time: 60

--- a/doc/sphinx/config.rst
+++ b/doc/sphinx/config.rst
@@ -439,6 +439,22 @@ allocated for this job::
     reverse: squeue -h -w $NODE -o "%i"
     cache_time: 60
 
+The fourth section **slurmuser,su** defines a group source based on Slurm users.
+Each group is based on a username and contains the nodes currently
+allocated for jobs belonging to the username::
+
+    [slurmuser,su]
+    map: squeue -h -u $GROUP -o "%N" -t running
+    list: squeue -h -o "%i" -t R
+    reverse: squeue -h -w $NODE -o "%i"
+    cache_time: 60
+
+Example of use with :ref:`clush <clush-tool>` to execute a command on all nodes
+with running jobs of username::
+
+    $ clush -bw@su:username 'df -Ph /scratch'
+    $ clush -bw@su:username 'du -s /scratch/username' 
+
 :ref:`cache_time <group-external-caching>` is also set to 60 seconds instead
 of the default (3600s) to avoid caching results in memory for too long, because
 this group source is likely very dynamic (this is only useful for long-running

--- a/doc/sphinx/config.rst
+++ b/doc/sphinx/config.rst
@@ -444,7 +444,7 @@ Each group is based on a username and contains the nodes currently
 allocated for jobs belonging to the username::
 
     [slurmuser,su]
-    map: squeue -h -u $GROUP -o "%N" -t running
+    map: squeue -h -u $GROUP -o "%N" -t R
     list: squeue -h -o "%i" -t R
     reverse: squeue -h -w $NODE -o "%i"
     cache_time: 60


### PR DESCRIPTION
We have found the need to execute a parallel command on all nodes running jobs belonging to a particular user. If you add a "slurmuser" section to the /etc/clustershell/groups.conf.d/slurm.conf file, you can now run commands such as:

$ clush -bw@su:username 'df -Ph /scratch'
$ clush -bw@su:username 'du -s /scratch/username'

I hope that others may find this feature useful. 