### PR TITLE
Slurm bindings

### DIFF
--- a/conf/groups.conf.d/slurm.conf.example
+++ b/conf/groups.conf.d/slurm.conf.example
@@ -36,6 +36,6 @@ cache_time: 60
 #
 [slurmuser,su]
 map: squeue -h -u $GROUP -o "%N" -t R
-list: squeue -h -o "%i" -t R
-reverse: squeue -h -w $NODE -o "%i"
+list: squeue -h -o "%u" -t R
+reverse: squeue -h -w $NODE -o "%u"
 cache_time: 60


### PR DESCRIPTION
Fix issue with the `slurmuser` binding, that was using job ids instead of user names.