### PR TITLE
doc: fix typo, %r is not for rank

### DIFF
--- a/doc/man/man1/clush.1
+++ b/doc/man/man1/clush.1
@@ -134,7 +134,7 @@ Instead of running provided command on remote nodes, \fBclush\fP can use the
 dedicated \fIexec\fP worker to launch the command \fIlocally\fP, for each node.
 Some parameters could be used in the command line to make a different
 command for each node. \fB%h\fP or \fB%host\fP will be replaced by node name and
-\fB%r\fP or \fB%rank\fP by the remote rank [0\-N] (to get a literal % use %%)
+\fB%n\fP or \fB%rank\fP by the remote rank [0\-N] (to get a literal % use %%)
 .TP
 .B File copying mode ( \fB\-\-copy\fP )
 When \fBclush\fP is started with the \fB\-c\fP or \fB\-\-copy\fP option, it will

--- a/doc/txt/clush.txt
+++ b/doc/txt/clush.txt
@@ -106,7 +106,7 @@ Local execution ( ``--worker=exec`` or ``-R exec`` )
   dedicated *exec* worker to launch the command *locally*, for each node.
   Some parameters could be used in the command line to make a different
   command for each node. ``%h`` or ``%host`` will be replaced by node name and
-  ``%r`` or ``%rank`` by the remote rank [0-N] (to get a literal % use %%)
+  ``%n`` or ``%rank`` by the remote rank [0-N] (to get a literal % use %%)
 
 File copying mode ( ``--copy`` )
   When ``clush`` is started with the ``-c`` or ``--copy`` option, it will


### PR DESCRIPTION
Hi,
Here is a small PR for a doc fix.

'man clush' says that '%r'  is correct for the exec worker. It should be '%n'.

Cheers,

Romain Fihue