### PR TITLE
Allow out-of-tree worker modules

### DIFF
--- a/doc/man/man1/clush.1
+++ b/doc/man/man1/clush.1
@@ -281,7 +281,7 @@ limit time to connect to a node
 limit time for command to run on the node
 .TP
 .BI \-R \ WORKER\fP,\fB \ \-\-worker\fB= WORKER
-worker name to use for connection (\fBexec\fP, \fBssh\fP, \fBrsh\fP, \fBpdsh\fP), default is \fBssh\fP
+worker name to use for connection (\fBexec\fP, \fBssh\fP, \fBrsh\fP, \fBpdsh\fP, or the name of a Python worker module), default is \fBssh\fP
 .TP
 .BI \-\-remote\fB= REMOTE
 whether to enable remote execution: in tree mode, \(aqyes\(aq forces connections to the leaf nodes for execution, \(aqno\(aq establishes connections up to the leaf parent nodes for execution (default is \(aqyes\(aq)

--- a/doc/sphinx/tools/clush.rst
+++ b/doc/sphinx/tools/clush.rst
@@ -633,6 +633,8 @@ By default, ClusterShell supports the following worker identifiers:
   installed; doesn't provide write support (eg. you cannot ``cat file | clush
   --worker pdsh``); it is primarily an 1-to-n worker example.
 
+Worker modules distributed outside of ClusterShell are also supported by
+specifying the case-sensitive full Python module name of a worker module.
 
 .. [#] LLNL parallel remote shell utility
    (https://computing.llnl.gov/linux/pdsh.html)

--- a/lib/ClusterShell/Defaults.py
+++ b/lib/ClusterShell/Defaults.py
@@ -55,17 +55,30 @@ def _load_workerclass(workername):
     """
     Return the class pointer matching `workername`.
 
+    This can be the 'short' name (such as `ssh`) or a fully-qualified
+    module path (such as ClusterShell.Worker.Ssh).
+
     The module is loaded if not done yet.
     """
-    modname = "ClusterShell.Worker.%s" % workername.capitalize()
 
+    # First try the worker name as a module under ClusterShell.Worker,
+    # but if that fails, try the worker name directly
+    try:
+        modname = "ClusterShell.Worker.%s" % workername.capitalize()
+        _import_module(modname)
+    except ImportError:
+        modname = workername
+        _import_module(modname)
+
+    # Get the class pointer
+    return sys.modules[modname].WORKER_CLASS
+
+def _import_module(modname):
+    """Import a python module if not done yet."""
     # Iterate over a copy of sys.modules' keys to avoid RuntimeError
     if modname.lower() not in [mod.lower() for mod in list(sys.modules)]:
         # Import module if not yet loaded
         __import__(modname)
-
-    # Get the class pointer
-    return sys.modules[modname].WORKER_CLASS
 
 def _local_workerclass(defaults):
     """Return default local worker class."""


### PR DESCRIPTION
If a worker is specified with a '.' in the name, assume it is a
fully qualified module name that should be used.  This supports
custom worker classes that are distributed outside of ClusterShell.