### PR TITLE
NodeUtils: allow YAML list to declare node groups

### DIFF
--- a/conf/groups.d/cluster.yaml.example
+++ b/conf/groups.d/cluster.yaml.example
@@ -39,6 +39,11 @@ racks:
     # and yes, ranges work for groups too!
     old: '@rack[1,3]'
     new: '@rack[2,4]'
+    # YAML lists
+    rack5:
+        - 'example[200-205]'  # some comment about example[200-205]
+        - 'example245'
+        - 'example300,example[401-406]'
 
 # Group source cpu:
 # define groups @cpu:ivy, @cpu:hsw and @cpu:all

--- a/doc/sphinx/config.rst
+++ b/doc/sphinx/config.rst
@@ -236,6 +236,11 @@ Here is an example of **/etc/clustershell/groups.d/cluster.yaml**::
         compute: 'node[0001-0288]'
         gpu: 'node[0001-0008]'
 
+        servers:                         # example of yaml list syntax for nodes
+            - 'server001'                # in a group
+            - 'server002,server101'                
+            - 'server[003-006]'
+
         cpu_only: '@compute!@gpu'        # example of inline set operation
                                          # define group @cpu_only with node[0009-0288]
 

--- a/lib/ClusterShell/NodeUtils.py
+++ b/lib/ClusterShell/NodeUtils.py
@@ -445,6 +445,8 @@ class GroupResolver(object):
         result = []
         assert source
         raw = getattr(source, 'resolv_%s' % what)(*args)
+        if isinstance(raw, list):
+            raw = ','.join(raw)
         for line in raw.splitlines():
             [result.append(x) for x in line.strip().split()]
         return result

--- a/tests/NodeSetGroupTest.py
+++ b/tests/NodeSetGroupTest.py
@@ -1589,6 +1589,19 @@ class YAMLGroupLoaderTest(unittest.TestCase):
         self.assertRaises(GroupResolverConfigError, YAMLGroupLoader, f.name)
 
 
+    def test_list_group(self):
+        f = make_temp_file(dedent("""
+            rednecks:
+                bubba: 
+                    - pickup-1
+                    - pickup-2
+                    - tractor-[1-2]""").encode('ascii'))
+        loader = YAMLGroupLoader(f.name)
+        sources = list(loader)
+        resolver = GroupResolver(sources[0])
+        self.assertEqual(resolver.group_nodes('bubba'),
+                [ 'pickup-1,pickup-2,tractor-[1-2]' ])
+
 class GroupResolverYAMLTest(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION

Allow the use of YAML list syntax when defining node groups.