### PR TITLE
Fix logic for detecting if Python2 is supported

### DIFF
--- a/clustershell.spec.in
+++ b/clustershell.spec.in
@@ -21,7 +21,7 @@
 %{!?__python3: %global __python3 python3}
 %{!?python3_shortver: %global python3_shortver %(%{__python3} -c 'import sys; print(str(sys.version_info.major) + "." + str(sys.version_info.minor))')}
 
-%if ! 0%{?rhel} >= 8 && ! 0%{?suse_version} > 1550
+%if 0%{?rhel} < 8 &&  0%{?suse_version} <= 1500
 %define py2 1
 %endif
 


### PR DESCRIPTION
This fixes Issue #445.
Thanks to Matt Ezell from  Oak Ridge.

Signed-off-by: Egbert Eich <eich@suse.com>