### PR TITLE
Return maxrc properly for Rsh Worker

### DIFF
--- a/conf/clush.conf
+++ b/conf/clush.conf
@@ -11,6 +11,7 @@ color: auto
 fd_max: 8192
 history_size: 100
 node_count: yes
+maxrc: no
 verbosity: 1
 
 # Add always all remote hosts to known_hosts without confirmation

--- a/conf/groups.conf.d/genders.conf.example
+++ b/conf/groups.conf.d/genders.conf.example
@@ -9,4 +9,5 @@
 map: nodeattr -n $GROUP
 all: nodeattr -n ALL
 list: nodeattr -l
+down: whatsup -n -d || /bin/true
 

--- a/doc/extras/vim/syntax/clushconf.vim
+++ b/doc/extras/vim/syntax/clushconf.vim
@@ -16,7 +16,7 @@ syn match  clushComment	    "#.*$"
 syn match  clushComment	    ";.*$"
 syn match  clushHeader	    "\[\w\+\]"
 
-syn keyword clushKeys       fanout command_timeout connect_timeout color fd_max history_size node_count verbosity
+syn keyword clushKeys       fanout command_timeout connect_timeout color fd_max history_size node_count maxrc verbosity
 syn keyword clushKeys       ssh_user ssh_path ssh_options
 syn keyword clushKeys       rsh_path rcp_path rcp_options
 

--- a/doc/man/man1/clush.1
+++ b/doc/man/man1/clush.1
@@ -185,6 +185,9 @@ exclude nodes from the node list
 .B \-a\fP,\fB  \-\-all
 run command on all nodes
 .TP
+.B \-D\fP,\fB  \-\-nodown
+exclude nodes that are down
+.TP
 .BI \-g \ GROUP\fP,\fB \ \-\-group\fB= GROUP
 run command on a group of nodes
 .TP

--- a/doc/man/man5/clush.conf.5
+++ b/doc/man/man5/clush.conf.5
@@ -103,6 +103,9 @@ list. Negative values imply unlimited history file size.
 Should \fBclush\fP display additional (node count) information in buffer
 header? (\fIyes\fP/\fIno\fP)
 .TP
+.B maxrc
+Should \fBclush\fP return the largest of command return codes? (\fIyes\fP/\fIno\fP)
+.TP
 .B verbosity
 Set the verbosity level: \fI0\fP (quiet), \fI1\fP (default), \fI2\fP (verbose) or more
 (debug).
@@ -146,6 +149,7 @@ history_size: 100
 color: auto
 fd_max: 10240
 node_count: yes
+maxrc: no
 
 .fi
 .sp

--- a/doc/man/man5/groups.conf.5
+++ b/doc/man/man5/groups.conf.5
@@ -64,7 +64,7 @@ Global configuration options. There should be only one Main section.
 .B \fIGroup_source\fP
 The \fIGroup_source\fP section(s) define the configuration for each node group
 source (or namespace). This configuration consists in external commands
-definition (map, all, list and reverse).
+definition (map, all, list, down, and reverse).
 .UNINDENT
 .sp
 Only \fIGroup_source\fP section(s) are allowed in additional configuration files.
@@ -122,6 +122,11 @@ external command in the same group source followed by \fBmap\fP for each group.
 Optional external shell command that should return the list of all groups
 for this group source (separated by space characters or by carriage
 returns).
+.TP
+.B down
+Optional external shell command that should return the list of all hosts
+that are down for this group source (separated by space characters or by
+carriage returns).
 .TP
 .B reverse
 Optional external shell command used to find the group(s) of a single

--- a/doc/sphinx/config.rst
+++ b/doc/sphinx/config.rst
@@ -64,6 +64,9 @@ The following table describes available *clush* config file settings.
 | node_count      | Should *clush* display additional (node count)     |
 |                 | information in buffer header? (yes/no)             |
 +-----------------+----------------------------------------------------+
+| maxrc           | Should *clush* return the largest of command       |
+|                 | return codes? (yes/no)                             |
++-----------------+----------------------------------------------------+
 | verbosity       | Set the verbosity level: 0 (quiet), 1 (default),   |
 |                 | 2 (verbose) or more (debug).                       |
 +-----------------+----------------------------------------------------+

--- a/doc/sphinx/config.rst
+++ b/doc/sphinx/config.rst
@@ -151,6 +151,7 @@ groups are bound to the source named *genders* by default::
     map: nodeattr -n $GROUP
     all: nodeattr -n ALL
     list: nodeattr -l
+    down: whatsup -n -d || /bin/true
 
     [slurm]
     map: sinfo -h -o "%N" -p $GROUP

--- a/doc/txt/clush.conf.txt
+++ b/doc/txt/clush.conf.txt
@@ -71,6 +71,8 @@ history_size
 node_count
   Should ``clush`` display additional (node count) information in buffer
   header? (`yes`/`no`)
+maxrc
+  Should ``clush`` return the largest of command return codes? (yes/no)
 verbosity
   Set the verbosity level: `0` (quiet), `1` (default), `2` (verbose) or more
   (debug).
@@ -109,6 +111,7 @@ Simple configuration file.
 | color: auto
 | fd_max: 10240
 | node_count: yes
+| maxrc: no
 |
 
 

--- a/doc/txt/clush.txt
+++ b/doc/txt/clush.txt
@@ -140,6 +140,7 @@ Selecting target nodes:
   -w NODES            nodes where to run the command
   -x NODES            exclude nodes from the node list
   -a, --all           run command on all nodes
+  -D, --nodown        exclude nodes that are down
   -g GROUP, --group=GROUP
                       run command on a group of nodes
   -X GROUP            exclude nodes from this group

--- a/lib/ClusterShell/CLI/Clush.py
+++ b/lib/ClusterShell/CLI/Clush.py
@@ -1027,6 +1027,9 @@ def main():
     task.set_info("connect_timeout", config.connect_timeout)
     task.set_info("command_timeout", config.command_timeout)
 
+    # Return code handling
+    task.set_info("maxrc", config.maxrc)
+
     # Enable stdout/stderr separation
     task.set_default("stderr", not options.gatherall)
 

--- a/lib/ClusterShell/CLI/Clush.py
+++ b/lib/ClusterShell/CLI/Clush.py
@@ -922,6 +922,11 @@ def main():
             msg = "Picked random nodes: %s" % nodeset_base
             print(Display.COLOR_RESULT_FMT % msg)
 
+    # If we need to remove nodes that are down do it here
+    if options.nodown:
+        down = NodeSet.fromdown()
+        nodeset_base.difference_update(down)
+
     # Set open files limit.
     set_fdlimit(config.fd_max, display)
 

--- a/lib/ClusterShell/CLI/Config.py
+++ b/lib/ClusterShell/CLI/Config.py
@@ -56,6 +56,7 @@ class ClushConfig(configparser.ConfigParser, object):
                      "color": THREE_CHOICES[-1], # auto
                      "verbosity": "%d" % VERB_STD,
                      "node_count": "yes",
+                     "maxrc": "no",
                      "fd_max": "8192"}
 
     def __init__(self, options, filename=None):
@@ -94,6 +95,8 @@ class ClushConfig(configparser.ConfigParser, object):
             self._set_main("command_timeout", options.command_timeout)
         if options.whencolor:
             self._set_main("color", options.whencolor)
+        if options.maxrc:
+            self._set_main("maxrc", options.maxrc)
 
         try:
             # -O/--option KEY=VALUE
@@ -211,6 +214,11 @@ class ClushConfig(configparser.ConfigParser, object):
     def node_count(self):
         """node_count value as a boolean"""
         return self.getboolean("Main", "node_count")
+
+    @property
+    def maxrc(self):
+        """maxrc value as a boolean"""
+        return self.getboolean("Main", "maxrc")
 
     @property
     def fd_max(self):

--- a/lib/ClusterShell/CLI/OptionParser.py
+++ b/lib/ClusterShell/CLI/OptionParser.py
@@ -106,6 +106,8 @@ class OptionParser(optparse.OptionParser):
         optgrp.add_option("-x", action="append", type="safestring",
                           dest="exclude", metavar="NODES",
                           help="exclude nodes from the node list")
+        optgrp.add_option("-D", "--nodown", action="store_true", dest="nodown",
+                          help="exclude down nodes from the node list")
         optgrp.add_option("-a", "--all", action="store_true", dest="nodes_all",
                           help="run command on all nodes")
         optgrp.add_option("-g", "--group", action="append", type="safestring",

--- a/lib/ClusterShell/NodeSet.py
+++ b/lib/ClusterShell/NodeSet.py
@@ -1285,6 +1285,24 @@ class NodeSet(NodeSetBase):
             raise NodeSetExternalError(errmsg)
         return inst
 
+    @classmethod
+    def fromdown(cls, groupsource=None, autostep=None, resolver=None):
+        """Class method that returns a new NodeSet with all nodes from optional
+        groupsource."""
+        inst = NodeSet(autostep=autostep, resolver=resolver)
+        try:
+            if not inst._resolver:
+                raise NodeSetExternalError("Group resolver is not defined")
+            else:
+                # fill this nodeset with all nodes found by resolver
+                down_nodes = inst._parser.group_resolver.down_nodes(groupsource)
+                inst = NodeSet.fromlist(down_nodes)
+        except NodeUtils.GroupResolverError as exc:
+            errmsg = "Group source error (%s: %s)" % (exc.__class__.__name__,
+                                                      exc)
+            raise NodeSetExternalError(errmsg)
+        return inst
+
     def __getstate__(self):
         """Called when pickling: remove references to group resolver."""
         odict = self.__dict__.copy()

--- a/lib/ClusterShell/NodeUtils.py
+++ b/lib/ClusterShell/NodeUtils.py
@@ -160,8 +160,8 @@ class UpcallGroupSource(GroupSource):
     """
 
     def __init__(self, name, map_upcall, all_upcall=None,
-                 list_upcall=None, reverse_upcall=None, cfgdir=None,
-                 cache_time=None):
+                 list_upcall=None, down_upcall=None, reverse_upcall=None,
+                 cfgdir=None, cache_time=None):
         GroupSource.__init__(self, name)
         self.verbosity = 0 # deprecated
         self.cfgdir = cfgdir
@@ -174,6 +174,8 @@ class UpcallGroupSource(GroupSource):
             self.upcalls['all'] = all_upcall
         if list_upcall:
             self.upcalls['list'] = list_upcall
+        if down_upcall:
+            self.upcalls['down'] = down_upcall
         if reverse_upcall:
             self.upcalls['reverse'] = reverse_upcall
             self.has_reverse = True
@@ -192,6 +194,7 @@ class UpcallGroupSource(GroupSource):
         """
         self._cache = {
             'map': {},
+            'down': {},
             'reverse': {}
         }
 
@@ -224,12 +227,12 @@ class UpcallGroupSource(GroupSource):
             raise GroupSourceNoUpcall(upcall, self)
 
         # Purge expired data from cache
-        if key in cache and cache[key][1] < time.time():
+        if key in cache and cache[key]:
             self.logger.debug("PURGE EXPIRED (%d)'%s'", cache[key][1], key)
             del cache[key]
 
         # Fetch the data if unknown of just purged
-        if key not in cache:
+        if key not in cache or not cache[key]:
             cache_expiry = time.time() + self.cache_time
             # $CFGDIR and $SOURCE always replaced
             args['CFGDIR'] = self.cfgdir
@@ -251,6 +254,12 @@ class UpcallGroupSource(GroupSource):
         the cached value if available.
         """
         return self._upcall_cache('list', self._cache, 'list')
+
+    def resolv_down(self):
+        """
+        Return a list of all nodes that are down in this group.
+        """
+        return self._upcall_cache('down', self._cache, 'down')
 
     def resolv_all(self):
         """
@@ -496,6 +505,13 @@ class GroupResolver(object):
         source = self._source(namespace)
         return self._list_nodes(source, 'all')
 
+    def down_nodes(self, namespace=None):
+        """
+        Find all nodes. You may specify an optional namespace.
+        """
+        source = self._source(namespace)
+        return self._list_nodes(source, 'down')
+
     def grouplist(self, namespace=None):
         """
         Get full group list. You may specify an optional
@@ -653,11 +669,13 @@ class GroupResolverConfig(GroupResolver):
                     if srcname != self.SECTION_MAIN:
                         # only map is a mandatory upcall
                         map_upcall = cfg.get(section, 'map', raw=True)
-                        all_upcall = list_upcall = reverse_upcall = ctime = None
+                        all_upcall = list_upcall = down_upcall = reverse_upcall = ctime = None
                         if cfg.has_option(section, 'all'):
                             all_upcall = cfg.get(section, 'all', raw=True)
                         if cfg.has_option(section, 'list'):
                             list_upcall = cfg.get(section, 'list', raw=True)
+                        if cfg.has_option(section, 'down'):
+                            down_upcall = cfg.get(section, 'down', raw=True)
                         if cfg.has_option(section, 'reverse'):
                             reverse_upcall = cfg.get(section, 'reverse',
                                                      raw=True)
@@ -665,9 +683,11 @@ class GroupResolverConfig(GroupResolver):
                             ctime = float(cfg.get(section, 'cache_time',
                                                   raw=True))
                         # add new group source
-                        self.add_source(UpcallGroupSource(srcname, map_upcall,
+                        self.add_source(UpcallGroupSource(srcname,
+                                                          map_upcall,
                                                           all_upcall,
                                                           list_upcall,
+                                                          down_upcall,
                                                           reverse_upcall,
                                                           cfgdir, ctime))
         except (NoSectionError, NoOptionError, ValueError) as exc:

--- a/lib/ClusterShell/Worker/Rsh.py
+++ b/lib/ClusterShell/Worker/Rsh.py
@@ -26,6 +26,7 @@ This is also the base class for rsh evolutions, like Ssh worker.
 
 import os
 import shlex
+import re
 
 from ClusterShell.Worker.Exec import ExecClient, CopyClient, ExecWorker
 
@@ -45,6 +46,7 @@ class RshClient(ExecClient):
         path = task.info("rsh_path") or "rsh"
         user = task.info("rsh_user")
         options = task.info("rsh_options")
+        maxrc = task.info("maxrc", False)
 
         cmd_l = [os.path.expanduser(pathc) for pathc in shlex.split(path)]
 
@@ -59,7 +61,30 @@ class RshClient(ExecClient):
         cmd_l.append("%s" % self.key)  # key is the node
         cmd_l.append("%s" % self.command)
 
+        # Save the return code from the command if required
+        if maxrc:
+            cmd_l.append("; echo XXRETCODE: $?")
+
         return (cmd_l, None)
+
+    def _parse_line(self, line, sname):
+
+        # Read the return code from the command if required
+        task = self.worker.task
+        maxrc = task.info("maxrc", False)
+        if maxrc:
+            match = re.search("^XXRETCODE: (\d+)$", line.decode("utf-8"))
+            if match:
+                self.worker.current_rc = int(match.group(1))
+            else:
+                self.worker._on_node_msgline(self.key, line, sname)
+        else:
+            self.worker._on_node_msgline(self.key, line, sname)
+
+    def _handle_read(self, sname):
+        """Engine is telling us a read is available."""
+        for msg in self._readlines(sname):
+            self._parse_line(msg, sname)
 
 
 class RcpClient(CopyClient):
@@ -122,12 +147,17 @@ class WorkerRsh(ExecWorker):
     Remote Copy (rcp) usage example:
        >>> worker = WorkerRsh(nodeset, handler=MyEventHandler(),
        ...                     source="/etc/my.conf",
-       ...                     dest="/etc/my.conf")
+       ...                     dest="/etc/my.conf.bak")
        >>> task.schedule(worker)      # schedule worker for execution
        >>> task.resume()              # run
 
     connect_timeout option is ignored by this worker.
     """
+
+    def _on_node_close(self, node, rc):
+        if rc is None or self.current_rc > rc:
+            rc = self.current_rc
+        ExecWorker._on_close(self, node, rc)
 
     SHELL_CLASS = RshClient
     COPY_CLASS = RcpClient


### PR DESCRIPTION
The current version of the Rsh Worker does not properly return
the max error code with the -S option. This commit adds in a little
"magic" to the end of the rsh command to pass back the return code
when requested. Basically works exactly as pdsh does to extract the
return code.