### PR TITLE
Add --nodown Option to Exclude Nodes That Are Down

### DIFF
--- a/conf/groups.conf.d/genders.conf.example
+++ b/conf/groups.conf.d/genders.conf.example
@@ -9,4 +9,5 @@
 map: nodeattr -n $GROUP
 all: nodeattr -n ALL
 list: nodeattr -l
+down: whatsup -n -d || /bin/true
 

--- a/doc/man/man1/clush.1
+++ b/doc/man/man1/clush.1
@@ -185,6 +185,9 @@ exclude nodes from the node list
 .B \-a\fP,\fB  \-\-all
 run command on all nodes
 .TP
+.B \-D\fP,\fB  \-\-nodown
+exclude nodes that are down
+.TP
 .BI \-g \ GROUP\fP,\fB \ \-\-group\fB= GROUP
 run command on a group of nodes
 .TP

--- a/doc/man/man5/groups.conf.5
+++ b/doc/man/man5/groups.conf.5
@@ -64,7 +64,7 @@ Global configuration options. There should be only one Main section.
 .B \fIGroup_source\fP
 The \fIGroup_source\fP section(s) define the configuration for each node group
 source (or namespace). This configuration consists in external commands
-definition (map, all, list and reverse).
+definition (map, all, list, down, and reverse).
 .UNINDENT
 .sp
 Only \fIGroup_source\fP section(s) are allowed in additional configuration files.
@@ -122,6 +122,11 @@ external command in the same group source followed by \fBmap\fP for each group.
 Optional external shell command that should return the list of all groups
 for this group source (separated by space characters or by carriage
 returns).
+.TP
+.B down
+Optional external shell command that should return the list of all hosts
+that are down for this group source (separated by space characters or by
+carriage returns).
 .TP
 .B reverse
 Optional external shell command used to find the group(s) of a single

--- a/doc/sphinx/config.rst
+++ b/doc/sphinx/config.rst
@@ -148,6 +148,7 @@ groups are bound to the source named *genders* by default::
     map: nodeattr -n $GROUP
     all: nodeattr -n ALL
     list: nodeattr -l
+    down: whatsup -n -d || /bin/true
 
     [slurm]
     map: sinfo -h -o "%N" -p $GROUP

--- a/doc/txt/clush.txt
+++ b/doc/txt/clush.txt
@@ -140,6 +140,7 @@ Selecting target nodes:
   -w NODES            nodes where to run the command
   -x NODES            exclude nodes from the node list
   -a, --all           run command on all nodes
+  -D, --nodown        exclude nodes that are down
   -g GROUP, --group=GROUP
                       run command on a group of nodes
   -X GROUP            exclude nodes from this group

--- a/lib/ClusterShell/CLI/Clush.py
+++ b/lib/ClusterShell/CLI/Clush.py
@@ -922,6 +922,11 @@ def main():
             msg = "Picked random nodes: %s" % nodeset_base
             print(Display.COLOR_RESULT_FMT % msg)
 
+    # If we need to remove nodes that are down do it here
+    if options.nodown:
+        down = NodeSet.fromdown()
+        nodeset_base.difference_update(down)
+
     # Set open files limit.
     set_fdlimit(config.fd_max, display)
 

--- a/lib/ClusterShell/CLI/OptionParser.py
+++ b/lib/ClusterShell/CLI/OptionParser.py
@@ -106,6 +106,8 @@ class OptionParser(optparse.OptionParser):
         optgrp.add_option("-x", action="append", type="safestring",
                           dest="exclude", metavar="NODES",
                           help="exclude nodes from the node list")
+        optgrp.add_option("-D", "--nodown", action="store_true", dest="nodown",
+                          help="exclude down nodes from the node list")
         optgrp.add_option("-a", "--all", action="store_true", dest="nodes_all",
                           help="run command on all nodes")
         optgrp.add_option("-g", "--group", action="append", type="safestring",

--- a/lib/ClusterShell/NodeSet.py
+++ b/lib/ClusterShell/NodeSet.py
@@ -1285,6 +1285,24 @@ class NodeSet(NodeSetBase):
             raise NodeSetExternalError(errmsg)
         return inst
 
+    @classmethod
+    def fromdown(cls, groupsource=None, autostep=None, resolver=None):
+        """Class method that returns a new NodeSet with all nodes from optional
+        groupsource."""
+        inst = NodeSet(autostep=autostep, resolver=resolver)
+        try:
+            if not inst._resolver:
+                raise NodeSetExternalError("Group resolver is not defined")
+            else:
+                # fill this nodeset with all nodes found by resolver
+                down_nodes = inst._parser.group_resolver.down_nodes(groupsource)
+                inst = NodeSet.fromlist(down_nodes)
+        except NodeUtils.GroupResolverError as exc:
+            errmsg = "Group source error (%s: %s)" % (exc.__class__.__name__,
+                                                      exc)
+            raise NodeSetExternalError(errmsg)
+        return inst
+
     def __getstate__(self):
         """Called when pickling: remove references to group resolver."""
         odict = self.__dict__.copy()

--- a/lib/ClusterShell/NodeUtils.py
+++ b/lib/ClusterShell/NodeUtils.py
@@ -160,8 +160,8 @@ class UpcallGroupSource(GroupSource):
     """
 
     def __init__(self, name, map_upcall, all_upcall=None,
-                 list_upcall=None, reverse_upcall=None, cfgdir=None,
-                 cache_time=None):
+                 list_upcall=None, down_upcall=None, reverse_upcall=None,
+                 cfgdir=None, cache_time=None):
         GroupSource.__init__(self, name)
         self.verbosity = 0 # deprecated
         self.cfgdir = cfgdir
@@ -174,6 +174,8 @@ class UpcallGroupSource(GroupSource):
             self.upcalls['all'] = all_upcall
         if list_upcall:
             self.upcalls['list'] = list_upcall
+        if down_upcall:
+            self.upcalls['down'] = down_upcall
         if reverse_upcall:
             self.upcalls['reverse'] = reverse_upcall
             self.has_reverse = True
@@ -192,6 +194,7 @@ class UpcallGroupSource(GroupSource):
         """
         self._cache = {
             'map': {},
+            'down': {},
             'reverse': {}
         }
 
@@ -224,12 +227,12 @@ class UpcallGroupSource(GroupSource):
             raise GroupSourceNoUpcall(upcall, self)
 
         # Purge expired data from cache
-        if key in cache and cache[key][1] < time.time():
+        if key in cache and cache[key]:
             self.logger.debug("PURGE EXPIRED (%d)'%s'", cache[key][1], key)
             del cache[key]
 
         # Fetch the data if unknown of just purged
-        if key not in cache:
+        if key not in cache or not cache[key]:
             cache_expiry = time.time() + self.cache_time
             # $CFGDIR and $SOURCE always replaced
             args['CFGDIR'] = self.cfgdir
@@ -251,6 +254,12 @@ class UpcallGroupSource(GroupSource):
         the cached value if available.
         """
         return self._upcall_cache('list', self._cache, 'list')
+
+    def resolv_down(self):
+        """
+        Return a list of all nodes that are down in this group.
+        """
+        return self._upcall_cache('down', self._cache, 'down')
 
     def resolv_all(self):
         """
@@ -496,6 +505,13 @@ class GroupResolver(object):
         source = self._source(namespace)
         return self._list_nodes(source, 'all')
 
+    def down_nodes(self, namespace=None):
+        """
+        Find all nodes. You may specify an optional namespace.
+        """
+        source = self._source(namespace)
+        return self._list_nodes(source, 'down')
+
     def grouplist(self, namespace=None):
         """
         Get full group list. You may specify an optional
@@ -653,11 +669,13 @@ class GroupResolverConfig(GroupResolver):
                     if srcname != self.SECTION_MAIN:
                         # only map is a mandatory upcall
                         map_upcall = cfg.get(section, 'map', raw=True)
-                        all_upcall = list_upcall = reverse_upcall = ctime = None
+                        all_upcall = list_upcall = down_upcall = reverse_upcall = ctime = None
                         if cfg.has_option(section, 'all'):
                             all_upcall = cfg.get(section, 'all', raw=True)
                         if cfg.has_option(section, 'list'):
                             list_upcall = cfg.get(section, 'list', raw=True)
+                        if cfg.has_option(section, 'down'):
+                            down_upcall = cfg.get(section, 'down', raw=True)
                         if cfg.has_option(section, 'reverse'):
                             reverse_upcall = cfg.get(section, 'reverse',
                                                      raw=True)
@@ -665,9 +683,11 @@ class GroupResolverConfig(GroupResolver):
                             ctime = float(cfg.get(section, 'cache_time',
                                                   raw=True))
                         # add new group source
-                        self.add_source(UpcallGroupSource(srcname, map_upcall,
+                        self.add_source(UpcallGroupSource(srcname,
+                                                          map_upcall,
                                                           all_upcall,
                                                           list_upcall,
+                                                          down_upcall,
                                                           reverse_upcall,
                                                           cfgdir, ctime))
         except (NoSectionError, NoOptionError, ValueError) as exc:


### PR DESCRIPTION
Add in an option that is similar to the -v option in pdsh. The idea
is to skip all hosts that are currently down for one reason or another.
The groups.conf file would have something like this in it:

[genders]
map: nodeattr -n $GROUP
all: nodeattr -n -A
list: nodeattr -l
down: whatsup -n -d || /bin/true

Example usage without -D:
> clush -a -b /path/to/command.sh
host8: mcmd: connect failed: No route to host
host12: mcmd: connect failed: No route to host
clush: host[8,12] (2): exited with exit code 1
---------------
host[1-7,9-11] (10)
---------------
Hello World

Example usage with -D:
> clush -D -a -b /path/to/command.sh
---------------
host[1-7,9-11] (10)
---------------
Hello World