### PR TITLE
xCAT binding: add support for spaces in group names.

### DIFF
--- a/conf/groups.conf.d/xcat.conf.example
+++ b/conf/groups.conf.d/xcat.conf.example
@@ -8,7 +8,7 @@
 [xcat]
 
 # list the nodes in the specified node group
-map: lsdef -s -t node $GROUP | cut -d' ' -f1
+map: lsdef -s -t node "$GROUP" | cut -d' ' -f1
 
 # list all the nodes defined in the xCAT tables
 all: lsdef -s -t node | cut -d' ' -f1


### PR DESCRIPTION
What do you mean group name shouldn't contain spaces?