### PR TITLE
Worker.Rsh: use raw string in RshClient

### DIFF
--- a/lib/ClusterShell/Worker/Rsh.py
+++ b/lib/ClusterShell/Worker/Rsh.py
@@ -74,7 +74,7 @@ class RshClient(ExecClient):
 
     def _on_nodeset_msgline(self, nodes, msg, sname):
         """Override _on_nodeset_msgline to parse magic return code"""
-        match = re.search("^XXRETCODE: (\d+)$", msg.decode())
+        match = re.search(r"^XXRETCODE: (\d+)$", msg.decode())
         if match:
             self.rsh_rc = int(match.group(1))
         else:


### PR DESCRIPTION
Fixes the following warning:

Rsh.py:77: DeprecationWarning: invalid escape sequence \d
  match = re.search("^XXRETCODE: (\d+)$", msg.decode())

Signed-off-by: Stephane Thiell <sthiell@stanford.edu>