### PR TITLE
NodeSet: add special notation @@source to expand group names

### DIFF
--- a/doc/man/man1/cluset.1
+++ b/doc/man/man1/cluset.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH CLUSET 1 "2019-12-01" "1.8.3" "ClusterShell User Manual"
+.TH CLUSET 1 "2022-03-19" "1.8.4" "ClusterShell User Manual"
 .SH NAME
 cluset \- compute advanced cluster node set operations
 .
@@ -225,7 +225,7 @@ node[0\-4,11\-13]
 .sp
 This computes a folded nodeset containing nodes found in group @gpu and @slurm:bigmem, but not in both, minus the nodes found in odd chassis groups from 1 to 9.
 .TP
-.B "All nodes" extension (v1.7+)
+.B "All nodes" extension
 The \fB@*\fP and \fB@SOURCE:*\fP special notations may be used in extended patterns to represent all nodes (in SOURCE) according to the \fIall\fP external shell command (see \fBgroups.conf\fP(5)) and are equivalent to:
 .INDENT 7.0
 .INDENT 3.5
@@ -233,6 +233,21 @@ The \fB@*\fP and \fB@SOURCE:*\fP special notations may be used in extended patte
 .TP
 .B $ cluset [\-s SOURCE] \-a \-f
 .UNINDENT
+.UNINDENT
+.UNINDENT
+.TP
+.B Group names in expressions
+The \fB@@SOURCE\fP notation may be used to access all group names from the specified SOURCE (or from the default group source when just \fB@@\fP is used) in node set expressions; this works with either file\-based group sources or with external group sources that have the \fIlist\fP upcall defined (see \fBgroups.conf\fP(5)):
+.INDENT 7.0
+.INDENT 3.5
+.INDENT 0.0
+.TP
+.B $ cluset \-f @@rack
+.UNINDENT
+.nf
+J[1\-3]
+.fi
+.sp
 .UNINDENT
 .UNINDENT
 .UNINDENT

--- a/doc/man/man1/nodeset.1
+++ b/doc/man/man1/nodeset.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH NODESET 1 "2021-11-03" "1.8.4" "ClusterShell User Manual"
+.TH NODESET 1 "2022-03-19" "1.8.4" "ClusterShell User Manual"
 .SH NAME
 nodeset \- compute advanced nodeset operations
 .
@@ -225,7 +225,7 @@ node[0\-4,11\-13]
 .sp
 This computes a folded nodeset containing nodes found in group @gpu and @slurm:bigmem, but not in both, minus the nodes found in odd chassis groups from 1 to 9.
 .TP
-.B "All nodes" extension (v1.7+)
+.B "All nodes" extension
 The \fB@*\fP and \fB@SOURCE:*\fP special notations may be used in extended patterns to represent all nodes (in SOURCE) according to the \fIall\fP external shell command (see \fBgroups.conf\fP(5)) and are equivalent to:
 .INDENT 7.0
 .INDENT 3.5
@@ -233,6 +233,21 @@ The \fB@*\fP and \fB@SOURCE:*\fP special notations may be used in extended patte
 .TP
 .B $ nodeset [\-s SOURCE] \-a \-f
 .UNINDENT
+.UNINDENT
+.UNINDENT
+.TP
+.B Group names in expressions
+The \fB@@SOURCE\fP notation may be used to access all group names from the specified SOURCE (or from the default group source when just \fB@@\fP is used) in node set expressions; this works with either file\-based group sources or with external group sources that have the \fIlist\fP upcall defined (see \fBgroups.conf\fP(5)):
+.INDENT 7.0
+.INDENT 3.5
+.INDENT 0.0
+.TP
+.B $ nodeset \-f @@rack
+.UNINDENT
+.nf
+J[1\-3]
+.fi
+.sp
 .UNINDENT
 .UNINDENT
 .UNINDENT

--- a/doc/sphinx/tools/nodeset.rst
+++ b/doc/sphinx/tools/nodeset.rst
@@ -634,9 +634,13 @@ configured group sources and also display the default group source (unless
 Listing group names
 """""""""""""""""""
 
-If the **list** external shell command is configured (see
-:ref:`node groups configuration <groups-config>`), it is possible to list
-available groups *from the default source* with the following commands::
+It is always possible to list the groups from a group source if the source is
+:ref:`file-based <group-file-based>`.
+If the source is an :ref:`external group source <group-external-sources>`, the
+**list** upcall must be configured (see also:
+:ref:`node groups configuration <groups-config>`).
+
+To list available groups *from the default source*, use the following command::
 
     $ nodeset -l
     @mgnt
@@ -645,7 +649,7 @@ available groups *from the default source* with the following commands::
     @login
     @compute
 
-Or, to list groups *from a specific group source*, use *-l* in conjunction
+To list groups *from a specific group source*, use *-l* in conjunction
 with *-s* (or *--groupsource*)::
 
     $ nodeset -l -s slurm
@@ -666,6 +670,47 @@ Or, to list groups *from all available group sources*, use *-L* (or
 
 You can also use ``nodeset -ll`` or ``nodeset -LL`` to see each group's
 associated node sets.
+
+Listing group names in expressions
+""""""""""""""""""""""""""""""""""
+
+ClusterShell 1.8.5 introduces a new operator **@@** optionally followed by
+a source name (e.g. **@@source**) to access the list of *raw group names* of
+the source (without the **@** prefix). If no source is specified (as in *just*
+**@@**), the default group source is used (see :ref:`groups_config_conf`).
+The **@@** operator may be used in any node set expression to manipulate group
+names as a node set.
+
+Example with the default group source::
+
+    $ nodeset -l
+    @mgnt
+    @mds
+    @oss
+    @login
+    @compute
+    
+    $ nodeset -e @@
+    compute login mds mgnt oss
+
+Example with a group source "rack" that defines group names from rack
+locations in a data center::
+
+    $ nodeset -l -s rack
+    @rack:J1
+    @rack:J2
+    @rack:J3
+    
+    $ nodeset -f @@rack
+    J[1-3]
+
+A set of valid, indexed group sources is also accepted by the **@@** operator
+(e.g. **@@dc[1-3]**).
+
+
+.. warning:: An error is generated when using **@@** in an expression if the
+             source is not valid (e.g. invalid name, not configured or upcalls
+             not currently working).
 
 
 Using node groups in basic commands

--- a/doc/txt/cluset.txt
+++ b/doc/txt/cluset.txt
@@ -7,7 +7,7 @@ compute advanced cluster node set operations
 --------------------------------------------
 
 :Author: Stephane Thiell <sthiell@stanford.edu>
-:Date:   2021-11-03
+:Date:   2022-03-19
 :Copyright: GNU Lesser General Public License version 2.1 or later (LGPLv2.1+)
 :Version: 1.8.4
 :Manual section: 1
@@ -131,10 +131,18 @@ Example of advanced usage
 
   This computes a folded nodeset containing nodes found in group @gpu and @slurm:bigmem, but not in both, minus the nodes found in odd chassis groups from 1 to 9.
 
-"All nodes" extension (v1.7+)
+"All nodes" extension
   The ``@*`` and ``@SOURCE:*`` special notations may be used in extended patterns to represent all nodes (in SOURCE) according to the *all* external shell command (see ``groups.conf``\(5)) and are equivalent to:
 
     :$ cluset [-s SOURCE] -a -f:
+
+Group names in expressions
+  The ``@@SOURCE`` notation may be used to access all group names from the specified SOURCE (or from the default group source when just ``@@`` is used) in node set expressions; this works with either file-based group sources or with external group sources that have the *list* upcall defined (see ``groups.conf``\(5)):
+
+
+    :$ cluset -f @@rack:
+    
+    | J[1-3]
 
 NODE WILDCARDS
 ==============

--- a/doc/txt/nodeset.txt
+++ b/doc/txt/nodeset.txt
@@ -7,7 +7,7 @@ compute advanced nodeset operations
 -----------------------------------
 
 :Author: Stephane Thiell <sthiell@stanford.edu>
-:Date:   2021-11-03
+:Date:   2022-03-19
 :Copyright: GNU Lesser General Public License version 2.1 or later (LGPLv2.1+)
 :Version: 1.8.4
 :Manual section: 1
@@ -131,10 +131,18 @@ Example of advanced usage
 
   This computes a folded nodeset containing nodes found in group @gpu and @slurm:bigmem, but not in both, minus the nodes found in odd chassis groups from 1 to 9.
 
-"All nodes" extension (v1.7+)
+"All nodes" extension
   The ``@*`` and ``@SOURCE:*`` special notations may be used in extended patterns to represent all nodes (in SOURCE) according to the *all* external shell command (see ``groups.conf``\(5)) and are equivalent to:
 
     :$ nodeset [-s SOURCE] -a -f:
+
+Group names in expressions
+  The ``@@SOURCE`` notation may be used to access all group names from the specified SOURCE (or from the default group source when just ``@@`` is used) in node set expressions; this works with either file-based group sources or with external group sources that have the *list* upcall defined (see ``groups.conf``\(5)):
+
+    :$ nodeset -f @@rack:
+    
+    | J[1-3]
+
 
 NODE WILDCARDS
 ==============

--- a/lib/ClusterShell/NodeSet.py
+++ b/lib/ClusterShell/NodeSet.py
@@ -916,6 +916,8 @@ class ParsingEngine(object):
             namespace, group = grpstr.split(':', 1)
         if group == '*': # @* or @source:* magic
             reslist = self.all_nodes(namespace)
+        elif group.startswith('@'): # @@source group name list
+            reslist = self.grouplist(grpstr[1:])
         else:
             reslist = self.group_resolver.group_nodes(group, namespace)
         return ','.join(reslist), namespace


### PR DESCRIPTION
This change allows access to all group names of a specific source in
node set expressions. The special operator `@@` followed by the source
expands group names that can then be manipulated as a set.

Note: In that case, group names are not prefixed with @ and as such, not
further expanded into nodes by NodeSet.