### PR TITLE
slurm.conf.example: Filter out more Slurm node state flags

### DIFF
--- a/conf/groups.conf.d/slurm.conf.example
+++ b/conf/groups.conf.d/slurm.conf.example
@@ -18,8 +18,8 @@ reverse: sinfo -h -N -o "%R" -n $NODE
 [slurmstate,st]
 map: sinfo -h -o "%N" -t $GROUP
 all: sinfo -h -o "%N"
-list: sinfo -h -o "%T" | tr -d '*~#$@+'
-reverse: sinfo -h -N -o "%T" -n $NODE | tr -d '*~#$@+'
+list: sinfo -h -o "%T" | tr -d '*~#!%$@+^-'
+reverse: sinfo -h -N -o "%T" -n $NODE | tr -d '*~#!%$@+^-'
 cache_time: 60
 
 #


### PR DESCRIPTION
Slurm 21.08 introduced a new node state flag (^), and we missed a few before.
See https://slurm.schedmd.com/sinfo.html#SECTION_NODE-STATE-CODES for a complete list