### PR TITLE
tree mode: fix error with intermediate gateways (#471)

### DIFF
--- a/lib/ClusterShell/Worker/Tree.py
+++ b/lib/ClusterShell/Worker/Tree.py
@@ -202,7 +202,7 @@ class TreeWorker(DistantWorker):
         DistantWorker._set_task(self, task)
         # Now bound to task - initalize router
         self.topology = self.topology or task.topology
-        self.router = self.router or task._default_router()
+        self.router = task._default_router(self.router)
         self._launch(self.nodes)
         self._check_ini()
 


### PR DESCRIPTION
Intermediate gateways create a TreeWorker with a topology passed by
the parent node and a new root node, and instantiate their own
PropagationNodeRouter object.

When such TreeWorker is scheduled, we should set the task's default
router from it properly.

The error seen was:
...
File "ClusterShell/Propagation.py", line 411, in ev_close
    self.task.router.mark_unreachable(gateway)
    AttributeError: 'NoneType' object has no attribute 'mark_unreachable'

Fixes #471