### PR TITLE
RangeSet: add explicit intiter() method to iterate over integers

### DIFF
--- a/lib/ClusterShell/CLI/Nodeset.py
+++ b/lib/ClusterShell/CLI/Nodeset.py
@@ -287,7 +287,8 @@ def nodeset():
     if options.axis:
         if not options.axis.startswith('-'):
             # axis are 1-indexed in nodeset CLI (0 ignored)
-            xset.fold_axis = tuple(x-1 for x in RangeSet(options.axis) if x > 0)
+            xset.fold_axis = tuple(x-1 for x in \
+                                   RangeSet(options.axis).intiter() if x > 0)
         else:
             # negative axis index (only single number supported)
             xset.fold_axis = [int(options.axis)]

--- a/lib/ClusterShell/RangeSet.py
+++ b/lib/ClusterShell/RangeSet.py
@@ -85,8 +85,11 @@ class RangeSet(set):
     a simple display feature per RangeSet object, thus current padding value is
     not taken into account when computing set operations.
     RangeSet is itself an iterator over its items as integers (instead of
-    strings). To iterate over string items with optional padding, you can use
-    the :meth:`RangeSet.striter`: method.
+    strings). However, this behavior is going to change in the next version
+    v1.9. For compatibility, please use the explicit method
+    :meth:`.RangeSet.intiter` to iterate over the set's indexes as integers.
+    To iterate over string items (with zero-padding if present), please use the
+    :meth:`RangeSet.striter` method.
 
     RangeSet provides methods like :meth:`RangeSet.union`,
     :meth:`RangeSet.intersection`, :meth:`RangeSet.difference`,
@@ -225,7 +228,15 @@ class RangeSet(set):
         return sorted(set.__iter__(self))
 
     def __iter__(self):
-        """Iterate over each element in RangeSet."""
+        """Iterate over each element in RangeSet, currently as integers, with
+        no padding information.
+        To guarantee future compatibility, please use the methods intiter()
+        or striter() instead."""
+        return iter(self._sorted())
+
+    def intiter(self):
+        """Iterate over each element in RangeSet as integer.
+        Zero padding info is ignored."""
         return iter(self._sorted())
 
     def striter(self):

--- a/tests/RangeSetTest.py
+++ b/tests/RangeSetTest.py
@@ -1104,3 +1104,30 @@ class RangeSetTest(unittest.TestCase):
         self.assertEqual(r0.dim(), 0)
         r1 = RangeSet("1-10,15-20")
         self.assertEqual(r1.dim(), 1)
+
+    def test_intiter(self):
+        matches = [ 1, 3, 4, 5, 6, 7, 8, 11 ]
+        rgs = RangeSet.fromlist([ "11", "3", "5-8", "1", "4" ])
+        cnt = 0
+        for rg in rgs.intiter():
+            self.assertEqual(rg, matches[cnt])
+            cnt += 1
+        self.assertEqual(cnt, len(matches))
+        # with padding
+        rgs = RangeSet.fromlist([ "011", "003", "005-008", "001", "004" ])
+        cnt = 0
+        for rg in rgs.intiter():
+            self.assertTrue(isinstance(rg, int))
+            self.assertEqual(rg, matches[cnt])
+            cnt += 1
+        self.assertEqual(cnt, len(matches))
+        # with mixed length padding (add 01, 09 and 0001): not supported until 1.9
+        #matches = [ 1, 9 ] + matches + [ 1 ]
+        #rgs = RangeSet.fromlist([ "011", "01", "003", "005-008", "001", "0001", "09", "004" ])
+        #cnt = 0
+        #for rg in rgs.intiter():
+        #    print(rg)
+        #    self.assertTrue(isinstance(rg, int))
+        #    self.assertEqual(rg, matches[cnt])
+        #    cnt += 1
+        #self.assertEqual(cnt, len(matches))


### PR DESCRIPTION
This change adds RangeSet.intiter() to explicily request an iterator
over the indexes of the set as integers. It is highly recommended to use
intiter() or striter() when iterating over RangeSet.