### PR TITLE
clush: always close stdin stream of worker when it is not used

### DIFF
--- a/lib/ClusterShell/CLI/Clush.py
+++ b/lib/ClusterShell/CLI/Clush.py
@@ -676,13 +676,13 @@ def run_command(task, cmd, ns, timeout, display, remote, trytree):
         # this is the simpler but faster output handler
         handler = DirectOutputHandler(display)
 
+    stdin = task.default("USER_stdin_worker")
     worker = task.shell(cmd, nodes=ns, handler=handler, timeout=timeout,
-                        remote=remote, tree=trytree)
+                        remote=remote, tree=trytree, stdin=stdin)
     if ns is None:
         worker.set_key('LOCAL')
-    if task.default("USER_stdin_worker"):
+    if stdin:
         bind_stdin(worker, display)
-
     task.resume()
 
 def run_copy(task, sources, dest, ns, timeout, preserve_flag, display):
@@ -1031,9 +1031,6 @@ def main():
 
     # Enable stdout/stderr separation
     task.set_default("stderr", not options.gatherall)
-
-    # Prevent reading from stdin?
-    task.set_default("stdin", not options.nostdin)
 
     # Disable MsgTree buffering if not gathering outputs
     task.set_default("stdout_msgtree", display.gather or display.line_mode)

--- a/tests/CLIClushTest.py
+++ b/tests/CLIClushTest.py
@@ -606,6 +606,18 @@ class CLIClushTest_A(unittest.TestCase):
                        "foo[1-10]", "echo ok"], b"",
                       b"---------------\nfoo[1-10]\n---------------\nok\n")
 
+    def test_040_stdin_eof(self):
+        """test clush (stdin eof)"""
+        # should not block if connection to stdin cannot be established
+        # or of --nostdin is specified
+        self._clush_t(["-w", HOSTNAME, "cat"], None, b'')
+        self._clush_t(["-w", HOSTNAME, "--nostdin", "cat"], None, b'')
+        setattr(ClusterShell.CLI.Clush, '_f_user_interaction', True)
+        try:
+            self._clush_t(["-w", HOSTNAME, "cat"], None, b'')
+        finally:
+            delattr(ClusterShell.CLI.Clush, '_f_user_interaction')
+
 
 class CLIClushTest_B_StdinFailure(unittest.TestCase):
     """Unit test class for testing CLI/Clush.py and stdin failure"""


### PR DESCRIPTION
Pass explicit stdin boolean flag when calling Task.shell() to fix an
issue where the stdin stream of the worker is never closed, even if
not used.

This change should not impact any already working stdin workflow.

However, the following command from a tty should not block anymore:

$ clush -w nodes cat