### PR TITLE
Task: only terminate Task once (#110)

### DIFF
--- a/lib/ClusterShell/Task.py
+++ b/lib/ClusterShell/Task.py
@@ -950,7 +950,10 @@ class Task(object):
         """
         Abort completion subroutine.
         """
-        assert self._quit == True
+        assert self._quit is True
+
+        if self._terminated:
+            return
         self._terminated = True
 
         if kill:


### PR DESCRIPTION
Add a check using existing _terminated attribute to avoid terminating
a Task multiple times, which could cause issues.

Closes #110