### PR TITLE
Worker.Tree: fix start and bufferize early writes

### DIFF
--- a/lib/ClusterShell/Worker/Tree.py
+++ b/lib/ClusterShell/Worker/Tree.py
@@ -33,6 +33,7 @@ import tempfile
 
 from ClusterShell.Event import EventHandler
 from ClusterShell.NodeSet import NodeSet
+from ClusterShell.Worker.EngineClient import EnginePort
 from ClusterShell.Worker.Worker import DistantWorker, WorkerError
 from ClusterShell.Worker.Worker import _eh_sigspec_invoke_compat
 from ClusterShell.Worker.Exec import ExecWorker
@@ -53,7 +54,6 @@ class MetaWorkerEventHandler(EventHandler):
         """
         self.logger.debug("MetaWorkerEventHandler: ev_start")
         self.metaworker._start_count += 1
-        self.metaworker._check_ini()  # also generate ev_pickup events
 
     def ev_read(self, worker, node, sname, msg):
         """
@@ -93,10 +93,6 @@ class MetaWorkerEventHandler(EventHandler):
             for node in NodeSet._fromlist1(worker.iter_keys_timeout()):
                 self.metaworker._on_node_timeout(node)
         self.metaworker._check_fini()
-        #self._completed += 1
-        #if self._completed >= self.grpcount:
-        #    metaworker = self.metaworker
-        #    metaworker.eh.ev_close(metaworker)
 
 
 class TreeWorker(DistantWorker):
@@ -110,6 +106,28 @@ class TreeWorker(DistantWorker):
     TAR_CMD_FMT = "tar -cf - -C '%s' " \
                   "--transform \"s,^\\([^/]*\\)[/]*,\\1.$(hostname -s)/,\" " \
                   "'%s' | base64 -w 65536"
+
+    class _IOPortHandler(EventHandler):
+        """
+        Special control port event handler used for:
+        * start the TreeWorker when the engine starts
+        * early write handling: write buffering and eof tracking
+        """
+        def __init__(self, treeworker):
+            EventHandler.__init__(self)
+            self.treeworker = treeworker
+
+        def ev_port_start(self, port):
+            """Event when port is registered."""
+            self.treeworker._start()
+
+        def ev_msg(self, port, msg):
+            """
+            Message received: call appropriate worker method.
+            Used for TreeWorker.write() and set_write_eof().
+            """
+            func, args = msg[0], msg[1:]
+            func(self.treeworker, *args)
 
     def __init__(self, nodes, handler, timeout, **kwargs):
         """
@@ -144,6 +162,7 @@ class TreeWorker(DistantWorker):
         self._child_count = 0
         self._target_count = 0
         self._has_timeout = False
+        self._started = False
 
         if self.command is None and self.source is None:
             raise ValueError("missing command or source parameter in "
@@ -190,21 +209,17 @@ class TreeWorker(DistantWorker):
         # gateway (string) -> active targets selection
         self.gwtargets = {}
 
-    def _set_task(self, task):
-        """
-        Bind worker to task. Called by task.schedule().
-        TreeWorker metaworker: override to schedule sub-workers.
-        """
-        ##if fanout is None:
-        ##    fanout = self.router.fanout
-        ##self.task.set_info('fanout', fanout)
+        # IO port
+        self._port = EnginePort(handler=TreeWorker._IOPortHandler(self),
+                                autoclose=True)
 
-        DistantWorker._set_task(self, task)
-        # Now bound to task - initalize router
-        self.topology = self.topology or task.topology
-        self.router = task._default_router(self.router)
+    def _start(self):
+        # Engine has started: initalize router
+        self.topology = self.topology or self.task.topology
+        self.router = self.task._default_router(self.router)
         self._launch(self.nodes)
         self._check_ini()
+        self._started = True
 
     def _launch(self, nodes):
         self.logger.debug("TreeWorker._launch on %s (fanout=%d)", nodes,
@@ -392,7 +407,7 @@ class TreeWorker(DistantWorker):
         """
         Access underlying engine clients.
         """
-        return []
+        return [self._port]
 
     def _on_remote_node_msgline(self, node, msg, sname, gateway):
         """remote msg received"""
@@ -462,6 +477,7 @@ class TreeWorker(DistantWorker):
 
     def _on_node_timeout(self, node):
         DistantWorker._on_node_timeout(self, node)
+        self.logger.debug("_on_node_timeout %s (%s)", node, self._close_count)
         self._close_count += 1
         self._has_timeout = True
 
@@ -506,8 +522,18 @@ class TreeWorker(DistantWorker):
             self.task._pchannel(gateway, self).write(nodes=targets, buf=buf,
                                                      worker=self)
 
+    def _set_write_eof_remote(self):
+        for gateway, targets in self.gwtargets.items():
+            assert len(targets) > 0
+            self.task._pchannel(gateway, self).set_write_eof(nodes=targets,
+                                                             worker=self)
+
     def write(self, buf):
         """Write to worker clients."""
+        if not self._started:
+            self._port.msg_send((TreeWorker.write, buf))
+            return
+
         osexc = None
         # Differentiate directly handled writes from remote ones
         for worker in self.workers:
@@ -526,13 +552,15 @@ class TreeWorker(DistantWorker):
         Tell worker to close its writer file descriptor once flushed. Do not
         perform writes after this call.
         """
+        if not self._started:
+            self._port.msg_send((TreeWorker.set_write_eof, ))
+            return
+
         # Differentiate directly handled EOFs from remote ones
         for worker in self.workers:
             worker.set_write_eof()
-        for gateway, targets in self.gwtargets.items():
-            assert len(targets) > 0
-            self.task._pchannel(gateway, self).set_write_eof(nodes=targets,
-                                                             worker=self)
+
+        self._set_write_eof_remote()
 
     def abort(self):
         """Abort processing any action by this worker."""

--- a/tests/TreeWorkerTest.py
+++ b/tests/TreeWorkerTest.py
@@ -17,7 +17,8 @@ import shutil
 import unittest
 
 from ClusterShell.NodeSet import NodeSet
-from ClusterShell.Task import task_self, task_terminate
+from ClusterShell.Task import task_self, task_terminate, task_wait
+from ClusterShell.Task import Task, task_cleanup
 from ClusterShell.Topology import TopologyGraph
 from ClusterShell.Worker.Tree import TreeWorker, WorkerTree
 
@@ -233,12 +234,19 @@ class TreeWorkerTest(unittest.TestCase):
         self.assertEqual(teh.ev_close_cnt, 1)
         self.assertEqual(teh.last_read, b'Lorem Ipsum')
 
-    def _tree_run_write(self, target):
+    def _tree_run_write(self, target, separate_thread=False):
+        if separate_thread:
+            task = Task()
+        else:
+            task = self.task
         teh = TEventHandler()
-        worker = self.task.shell('cat', nodes=target, handler=teh)
+        worker = task.shell('cat', nodes=target, handler=teh)
         worker.write(b'Lorem Ipsum')
         worker.set_write_eof()
-        self.task.run()
+        task.run()
+        if separate_thread:
+            task_wait()
+            task_cleanup()
         self.assertEqual(teh.ev_start_cnt, 1)
         self.assertEqual(teh.ev_pickup_cnt, 1)
         self.assertEqual(teh.ev_read_cnt, 1)
@@ -264,6 +272,22 @@ class TreeWorkerTest(unittest.TestCase):
     def test_tree_run_write_gateway(self):
         """test tree run with write(), gateway is target, not in topology"""
         self._tree_run_write(NODE_GATEWAY)
+
+    def test_tree_run_write_distant_mt(self):
+        """test tree run with write(), distant target, separate thread"""
+        self._tree_run_write(NODE_DISTANT, separate_thread=True)
+
+    def test_tree_run_write_direct_mt(self):
+        """test tree run with write(), direct target, in topology, separate thread"""
+        self._tree_run_write(NODE_DIRECT, separate_thread=True)
+
+    def test_tree_run_write_foreign_mt(self):
+        """test tree run with write(), direct target, not in topology, separate thread"""
+        self._tree_run_write(NODE_FOREIGN, separate_thread=True)
+
+    def test_tree_run_write_gateway_mt(self):
+        """test tree run with write(), gateway is target, not in topology, separate thread"""
+        self._tree_run_write(NODE_GATEWAY, separate_thread=True)
 
     def _tree_copy_file(self, target):
         teh = TEventHandler()


### PR DESCRIPTION
With the help of an EnginePort object used for Engine control and write
message queueing, this change implements:
(1) a proper asynchrounous start for TreeWorker, which is now only
triggered when the engine actually starts
(2) buffered early writes