### PR TITLE
CLIConfigTest: Use integer division for soft limit computation

### DIFF
--- a/tests/CLIConfigTest.py
+++ b/tests/CLIConfigTest.py
@@ -229,7 +229,7 @@ class CLIClushConfigTest(unittest.TestCase):
         display = Display(options, config)
 
         # force a lower soft limit
-        resource.setrlimit(resource.RLIMIT_NOFILE, (hard2/2, hard))
+        resource.setrlimit(resource.RLIMIT_NOFILE, (hard2//2, hard))
         # max_fdlimit should increase soft limit again
         set_fdlimit(config.fd_max, display)
         # verify


### PR DESCRIPTION
The `CLI.Config.ClushConfig (setrlimit)` test fails with `python3.10` with an error:

```
       resource.setrlimit(resource.RLIMIT_NOFILE, (hard2/2, hard))
   TypeError: 'float' object cannot be interpreted as an integer
```
The integer division solves the problem.