### PR TITLE
Fix error in building config paths list

### DIFF
--- a/lib/ClusterShell/Defaults.py
+++ b/lib/ClusterShell/Defaults.py
@@ -92,7 +92,7 @@ def _distant_workerclass(defaults):
 def config_paths(config_name):
     """Return default path list for a ClusterShell config file name."""
     return [os.path.join(os.environ.get('CLUSTERSHELL_CFGDIR',
-                                        '/etc/clustershell/%s'),
+                                        '/etc/clustershell'),
 			             config_name), # global config file
             # default pip --user config file
             os.path.expanduser('~/.local/etc/clustershell/%s' % config_name),


### PR DESCRIPTION
Fix an issue building the config paths list when `CLUSTERSHELL_CFGDIR` is not defined (extra `%s` in path).