### PR TITLE
Worker: remove old last_*() methods (#226)

### DIFF
--- a/lib/ClusterShell/Worker/Worker.py
+++ b/lib/ClusterShell/Worker/Worker.py
@@ -289,42 +289,6 @@ class DistantWorker(Worker):
 
         self.task._timeout_add(self, node)
 
-    def last_node(self):
-        """
-        Get last node, useful to get the node in an EventHandler
-        callback like ev_read().
-        [DEPRECATED] use current_node
-        """
-        warnings.warn("use current_node instead", DeprecationWarning)
-        return self.current_node
-
-    def last_read(self):
-        """
-        Get last (node, buffer), useful in an EventHandler.ev_read()
-        [DEPRECATED] use (current_node, current_msg)
-        """
-        warnings.warn("use current_node and current_msg instead",
-                      DeprecationWarning)
-        return self.current_node, self.current_msg
-
-    def last_error(self):
-        """
-        Get last (node, error_buffer), useful in an EventHandler.ev_error()
-        [DEPRECATED] use (current_node, current_errmsg)
-        """
-        warnings.warn("use current_node and current_errmsg instead",
-                      DeprecationWarning)
-        return self.current_node, self.current_errmsg
-
-    def last_retcode(self):
-        """
-        Get last (node, rc), useful in an EventHandler.ev_hup()
-        [DEPRECATED] use (current_node, current_rc)
-        """
-        warnings.warn("use current_node and current_rc instead",
-                      DeprecationWarning)
-        return self.current_node, self.current_rc
-
     def node_buffer(self, node):
         """Get specific node buffer."""
         return self.read(node, self.SNAME_STDOUT)
@@ -680,24 +644,6 @@ class WorkerSimple(StreamWorker):
     def writer_fileno(self):
         """Return the writer file descriptor as an integer."""
         return self.clients[0].streams['stdin'].fd
-
-    def last_read(self):
-        """
-        Get last read message.
-
-        [DEPRECATED] use current_msg
-        """
-        warnings.warn("use current_msg instead", DeprecationWarning)
-        return self.current_msg
-
-    def last_error(self):
-        """
-        Get last error message.
-
-        [DEPRECATED] use current_errmsg
-        """
-        warnings.warn("use current_errmsg instead", DeprecationWarning)
-        return self.current_errmsg
 
     def error(self):
         """Read worker error buffer."""

--- a/tests/TaskDistantMixin.py
+++ b/tests/TaskDistantMixin.py
@@ -734,25 +734,3 @@ class TaskDistantMixin(object):
         self.assertEqual(test_eh.hup_count, 2)
         self.assertEqual(test_eh.start_count, 1)
         self.assertEqual(test_eh.close_count, 1)
-
-    def test_last_deprecated(self):
-
-        class TestHandlerHandler(EventHandler):
-            def ev_read(self, worker):
-                with warnings.catch_warnings(record=True) as wngs:
-                    warnings.simplefilter("always")
-                    self.node, self.msg = worker.last_read()
-                    assert len(wngs) == 1
-                    assert issubclass(wngs[-1].category, DeprecationWarning)
-            def ev_hup(self, worker):
-                with warnings.catch_warnings(record=True) as wngs:
-                    warnings.simplefilter("always")
-                    self.node, self.rc = worker.last_retcode()
-                    assert len(wngs) == 1
-                    assert issubclass(wngs[-1].category, DeprecationWarning)
-
-        eh = TestHandlerHandler()
-        reader = self._task.shell("echo foobar", nodes=HOSTNAME, handler=eh)
-        self._task.resume()
-        self.assertEqual(eh.node, HOSTNAME)
-        self.assertEqual(eh.rc, 0)


### PR DESCRIPTION
Remove deprecated methods:
- Worker.last_error()
- Worker.last_node()
- Worker.last_read()
- Worker.last_retcode()

They have been deprecated since at least v1.6.