### PR TITLE
Worker: deprecate old EventHandler method signatures (#358)

### DIFF
--- a/tests/TaskDistantPdshMixin.py
+++ b/tests/TaskDistantPdshMixin.py
@@ -172,30 +172,28 @@ class TaskDistantPdshMixin(object):
         def ev_start(self, worker):
             self.test.assertEqual(self.flags, 0)
             self.flags |= EV_START
-        def ev_pickup(self, worker):
+        def ev_pickup(self, worker, node):
             self.test.assertTrue(self.flags & EV_START)
             self.flags |= EV_PICKUP
-            self.last_node = worker.current_node
-        def ev_read(self, worker):
+            self.last_node = node
+        def ev_read(self, worker, node, sname, msg):
             self.test.assertEqual(self.flags, EV_START | EV_PICKUP)
             self.flags |= EV_READ
-            self.last_node = worker.current_node
-            self.last_read = worker.current_msg
-        def ev_written(self, worker):
+            self.last_node = node
+            self.last_read = msg
+        def ev_written(self, worker, node, sname, size):
             self.test.assertTrue(self.flags & (EV_START | EV_PICKUP))
             self.flags |= EV_WRITTEN
-        def ev_hup(self, worker):
+        def ev_hup(self, worker, node, rc):
             self.test.assertTrue(self.flags & (EV_START | EV_PICKUP))
             self.flags |= EV_HUP
-            self.last_node = worker.current_node
-            self.last_rc = worker.current_rc
-        def ev_timeout(self, worker):
-            self.test.assertTrue(self.flags & EV_START)
-            self.flags |= EV_TIMEOUT
-            self.last_node = worker.current_node
-        def ev_close(self, worker):
+            self.last_node = node
+            self.last_rc = rc
+        def ev_close(self, worker, timedout):
             self.test.assertTrue(self.flags & EV_START)
             self.test.assertTrue(self.flags & EV_CLOSE == 0)
+            if timedout:
+                self.flags |= EV_TIMEOUT
             self.flags |= EV_CLOSE
 
     def testExplicitWorkerPdshShellEvents(self):
@@ -500,13 +498,13 @@ class TaskDistantPdshMixin(object):
         def ev_start(self, worker):
             self.start_count += 1
 
-        def ev_pickup(self, worker):
+        def ev_pickup(self, worker, node):
             self.pickup_count += 1
 
-        def ev_hup(self, worker):
+        def ev_hup(self, worker, node, rc):
             self.hup_count += 1
 
-        def ev_close(self, worker):
+        def ev_close(self, worker, timedout):
             self.close_count += 1
 
     def testWorkerEventCount(self):

--- a/tests/TaskEventTest.py
+++ b/tests/TaskEventTest.py
@@ -164,17 +164,15 @@ class TaskEventTest(unittest.TestCase):
         eh = LegacyTestHandler()
         # init worker
         worker = task.shell("echo abcdefghijklmnopqrstuvwxyz", handler=eh)
-        # future warnings: pickup + read + hup + close
-        #self.run_task_and_catch_warnings(task, 4)
-        self.run_task_and_catch_warnings(task, 0)
+        # warnings: pickup + read + hup + close
+        self.run_task_and_catch_warnings(task, 4)
         eh.do_asserts_read_notimeout()
         eh.reset_asserts()
 
         # test again
         worker = task.shell("echo abcdefghijklmnopqrstuvwxyz", handler=eh)
-        # future warnings: pickup + read + hup + close
-        #self.run_task_and_catch_warnings(task, 4)
-        self.run_task_and_catch_warnings(task, 0)
+        # warnings: pickup + read + hup + close
+        self.run_task_and_catch_warnings(task, 4)
         eh.do_asserts_read_notimeout()
 
     def test_simple_event_handler(self):
@@ -191,8 +189,21 @@ class TaskEventTest(unittest.TestCase):
         self.run_task_and_catch_warnings(task)
         eh.do_asserts_read_notimeout()
 
-    def test_simple_event_handler_with_task_timeout_legacy(self):
+    def test_simple_event_handler_with_timeout_legacy(self):
         """test simple event handler with timeout (legacy)"""
+        task = task_self()
+
+        eh = LegacyTestHandler()
+
+        task.shell("/bin/sleep 3", handler=eh, timeout=2)
+
+        # warnings: pickup + timeout + close
+        self.run_task_and_catch_warnings(task, 3)
+
+        eh.do_asserts_timeout()
+
+    def test_simple_event_handler_with_task_timeout_legacy(self):
+        """test simple event handler with task timeout (legacy)"""
         task = task_self()
 
         eh = LegacyTestHandler()
@@ -200,9 +211,8 @@ class TaskEventTest(unittest.TestCase):
         task.shell("/bin/sleep 3", handler=eh)
 
         try:
-            # future warnings: pickup + close
-            #self.run_task_and_catch_warnings(task, 2, task_timeout=2)
-            self.run_task_and_catch_warnings(task, 0, task_timeout=2)
+            # warnings: pickup + timeout + close
+            self.run_task_and_catch_warnings(task, 3, task_timeout=2)
         except TimeoutError:
             pass
         else:
@@ -211,7 +221,7 @@ class TaskEventTest(unittest.TestCase):
         eh.do_asserts_timeout()
 
     def test_simple_event_handler_with_task_timeout(self):
-        """test simple event handler with timeout (1.8+)"""
+        """test simple event handler with task timeout (1.8+)"""
         task = task_self()
 
         eh = TestHandler()
@@ -271,9 +281,8 @@ class TaskEventTest(unittest.TestCase):
         worker.write(content)
         worker.set_write_eof()
 
-        # future warnings: 1 x pickup + 1 x read + 1 x hup + 1 x close
-        #self.run_task_and_catch_warnings(task, 4)
-        self.run_task_and_catch_warnings(task, 0)
+        # warnings: 1 x pickup + 1 x read + 1 x hup + 1 x close
+        self.run_task_and_catch_warnings(task, 4)
         eh.do_asserts_read_write_notimeout()
 
     def test_popen_specific_behaviour(self):
@@ -348,10 +357,8 @@ class TaskEventTest(unittest.TestCase):
         worker = task.shell("/bin/uname", handler=eh)
         self.assertNotEqual(worker, None)
 
-        # future warnings: 1 x pickup + 1 x read + 2 x pickup + 3 x hup +
-        #                  3 x close
-        #self.run_task_and_catch_warnings(task, 10)
-        self.run_task_and_catch_warnings(task, 0)
+        # warnings: 1 x pickup + 1 x read + 2 x pickup + 3 x hup + 3 x close
+        self.run_task_and_catch_warnings(task, 10)
 
     class TOnTheFlyLauncher(EventHandler):
         """CS v1.8 Test Event handler to shedules commands on the fly"""
@@ -384,8 +391,7 @@ class TaskEventTest(unittest.TestCase):
         """test write on ev_start (legacy)"""
         task = task_self()
         task.shell("cat", handler=self.__class__.LegacyTWriteOnStart())
-        #self.run_task_and_catch_warnings(task, 1)  # future: read
-        self.run_task_and_catch_warnings(task, 0)
+        self.run_task_and_catch_warnings(task, 1)  # ev_read
 
     class TWriteOnStart(EventHandler):
         def ev_start(self, worker):
@@ -416,9 +422,8 @@ class TaskEventTest(unittest.TestCase):
                 worker = task.shell("echo ok; sleep 1", handler=eh)
                 self.assertTrue(worker is not None)
                 worker.write(b"OK\n")
-            # future warnings: 10 x read
-            #self.run_task_and_catch_warnings(task, 10)
-            self.run_task_and_catch_warnings(task, 0)
+            # warnings: 10 x read
+            self.run_task_and_catch_warnings(task, 10)
         finally:
             task.set_info("fanout", fanout)
 
@@ -451,9 +456,8 @@ class TaskEventTest(unittest.TestCase):
         task.shell("/bin/sleep 0.5", handler=eh)
         task.shell("/bin/sleep 0.5", handler=eh)
 
-        # future warnings: 3 x pickup + 3 x hup + 3 x close
-        #self.run_task_and_catch_warnings(task, 9)
-        self.run_task_and_catch_warnings(task, 0)
+        # warnings: 3 x pickup + 3 x hup + 3 x close
+        self.run_task_and_catch_warnings(task, 9)
 
         eh.do_asserts_noread_notimeout()
         self.assertEqual(eh.cnt_pickup, 3)
@@ -488,9 +492,8 @@ class TaskEventTest(unittest.TestCase):
             task.shell("/bin/sleep 0.5", handler=eh, key="n2")
             task.shell("/bin/sleep 0.5", handler=eh, key="n3")
 
-            # future warnings: 3 x pickup + 3 x hup + 3 x close
-            #self.run_task_and_catch_warnings(task, 9)
-            self.run_task_and_catch_warnings(task, 0)
+            # warnings: 3 x pickup + 3 x hup + 3 x close
+            self.run_task_and_catch_warnings(task, 9)
 
             eh.do_asserts_noread_notimeout()
             self.assertEqual(eh.cnt_pickup, 3)
@@ -530,9 +533,8 @@ class TaskEventTest(unittest.TestCase):
         worker.write(content)
         worker.set_write_eof()
 
-        # future warnings: pickup + read + hup + close
-        #self.run_task_and_catch_warnings(task, 4)
-        self.run_task_and_catch_warnings(task, 0)
+        # warnings: pickup + read + hup + close
+        self.run_task_and_catch_warnings(task, 4)
 
         eh.do_asserts_read_write_notimeout()
         self.assertEqual(eh.cnt_written, 1)

--- a/tests/TaskLocalMixin.py
+++ b/tests/TaskLocalMixin.py
@@ -575,7 +575,7 @@ class TaskLocalMixin(object):
     def testTaskAbortHandler(self):
 
         class AbortOnReadTestHandler(EventHandler):
-            def ev_read(self, worker):
+            def ev_read(self, worker, node, sname, msg):
                 self.has_ev_read = True
                 worker.task.abort()
                 assert False, "Shouldn't reach this line"
@@ -676,7 +676,7 @@ class TaskLocalMixin(object):
 
     def testSignalWorker(self):
         class TestSignalHandler(EventHandler):
-            def ev_read(self, worker):
+            def ev_read(self, worker, node, sname, msg):
                 pid = int(worker.current_msg)
                 os.kill(pid, signal.SIGTERM)
         task = task_self()
@@ -689,7 +689,7 @@ class TaskLocalMixin(object):
             def __init__(self, target_worker=None):
                 self.target_worker = target_worker
                 self.counter = 0
-            def ev_read(self, worker):
+            def ev_read(self, worker, node, sname, msg):
                 self.counter += 1
                 if self.counter == 100:
                     worker.write(b"another thing to read\n")
@@ -741,7 +741,7 @@ class TaskLocalMixin(object):
             def ev_start(self, worker):
                 self.workers.append(worker)
 
-            def ev_read(self, worker):
+            def ev_read(self, worker, node, sname, msg):
                 run_cnt = sum(e.registered for w in self.workers
                               for e in w._engine_clients())
                 self.max_run_cnt = max(self.max_run_cnt, run_cnt)
@@ -847,7 +847,7 @@ class TaskLocalMixin(object):
 
     def testKBI(self):
         class TestKBI(EventHandler):
-            def ev_read(self, worker):
+            def ev_read(self, worker, node, sname, msg):
                 raise KeyboardInterrupt
         task = task_self()
         ok = False
@@ -983,9 +983,9 @@ class TaskLocalMixin(object):
             def __init__(self):
                 self.pickup_count = 0
                 self.hup_count = 0
-            def ev_pickup(self, worker):
+            def ev_pickup(self, worker, node):
                 self.pickup_count += 1
-            def ev_hup(self, worker):
+            def ev_hup(self, worker, node, rc):
                 self.hup_count += 1
 
         task = task_self()
@@ -1036,7 +1036,7 @@ class TaskLocalMixin(object):
             def __init__(self, worker2):
                 self.worker2 = worker2
 
-            def ev_read(self, worker):
+            def ev_read(self, worker, node, sname, msg):
                 worker.task.schedule(self.worker2)
 
         worker2 = StreamWorker(handler=None)

--- a/tests/TaskMsgTreeTest.py
+++ b/tests/TaskMsgTreeTest.py
@@ -52,7 +52,7 @@ class TaskMsgTreeTest(unittest.TestCase):
     def testHotEnablingMsgTree(self):
         """test TaskMsgTree enabling at runtime (v1.7)"""
         class HotEH2(EventHandler):
-            def ev_read(self, worker):
+            def ev_read(self, worker, node, sname, msg):
                 worker.task.set_default("stdout_msgtree", True)
                 worker.task.shell("echo foo bar2") # default EH
         task = task_self()
@@ -67,7 +67,7 @@ class TaskMsgTreeTest(unittest.TestCase):
     def testHotDisablingMsgTree(self):
         """test TaskMsgTree disabling at runtime (v1.7)"""
         class HotEH2(EventHandler):
-            def ev_read(self, worker):
+            def ev_read(self, worker, node, sname, msg):
                 worker.task.set_default("stdout_msgtree", False)
                 worker.task.shell("echo foo bar2") # default EH
         task = task_self()

--- a/tests/TaskThreadJoinTest.py
+++ b/tests/TaskThreadJoinTest.py
@@ -106,7 +106,7 @@ class TaskThreadJoinTest(unittest.TestCase):
         class TestUnhandledException(Exception):
             """test exception"""
         class RaiseOnRead(EventHandler):
-            def ev_read(self, worker):
+            def ev_read(self, worker, node, sname, msg):
                 raise TestUnhandledException("you should see this exception")
 
         task = Task()

--- a/tests/TaskTimerTest.py
+++ b/tests/TaskTimerTest.py
@@ -170,19 +170,19 @@ class TaskTimerTest(unittest.TestCase):
             self.flags = 0
         def ev_start(self, worker):
             self.flags |= EV_START
-        def ev_read(self, worker):
+        def ev_read(self, worker, node, sname, msg):
             self.test.assertEqual(self.flags, EV_START)
             self.flags |= EV_READ
-        def ev_written(self, worker):
+        def ev_written(self, worker, node, sname, size):
             self.test.assertTrue(self.flags & EV_START)
             self.flags |= EV_WRITTEN
-        def ev_hup(self, worker):
+        def ev_hup(self, worker, node, rc):
             self.test.assertTrue(self.flags & EV_START)
             self.flags |= EV_HUP
         def ev_timeout(self, worker):
             self.test.assertTrue(self.flags & EV_START)
             self.flags |= EV_TIMEOUT
-        def ev_close(self, worker):
+        def ev_close(self, worker, timedout):
             self.test.assertTrue(self.flags & EV_START)
             self.flags |= EV_CLOSE
         def ev_timer(self, timer):
@@ -213,19 +213,19 @@ class TaskTimerTest(unittest.TestCase):
             self.flags = 0
         def ev_start(self, worker):
             self.flags |= EV_START
-        def ev_read(self, worker):
+        def ev_read(self, worker, node, sname, msg):
             self.test.assertEqual(self.flags, EV_START)
             self.flags |= EV_READ
         def ev_written(self, worker):
             self.test.assertTrue(self.flags & EV_START)
             self.flags |= EV_WRITTEN
-        def ev_hup(self, worker):
+        def ev_hup(self, worker, node, rc):
             self.test.assertTrue(self.flags & EV_START)
             self.flags |= EV_HUP
         def ev_timeout(self, worker):
             self.test.assertTrue(self.flags & EV_START)
             self.flags |= EV_TIMEOUT
-        def ev_close(self, worker):
+        def ev_close(self, worker, timedout):
             self.test.assertTrue(self.flags & EV_START)
             self.flags |= EV_CLOSE
         def ev_timer(self, timer):
@@ -257,19 +257,19 @@ class TaskTimerTest(unittest.TestCase):
             self.flags = 0
         def ev_start(self, worker):
             self.flags |= EV_START
-        def ev_read(self, worker):
+        def ev_read(self, worker, node, sname, msg):
             self.flags |= EV_READ
             self.timer.invalidate()
         def ev_written(self, worker):
             self.test.assertTrue(self.flags & EV_START)
             self.flags |= EV_WRITTEN
-        def ev_hup(self, worker):
+        def ev_hup(self, worker, node, rc):
             self.test.assertTrue(self.flags & EV_START)
             self.flags |= EV_HUP
         def ev_timeout(self, worker):
             self.test.assertTrue(self.flags & EV_START)
             self.flags |= EV_TIMEOUT
-        def ev_close(self, worker):
+        def ev_close(self, worker, timedout):
             self.test.assertTrue(self.flags & EV_START)
             self.flags |= EV_CLOSE
         def ev_timer(self, timer):
@@ -326,19 +326,19 @@ class TaskTimerTest(unittest.TestCase):
             self.flags = 0
         def ev_start(self, worker):
             self.flags |= EV_START
-        def ev_read(self, worker):
+        def ev_read(self, worker, node, sname, msg):
             self.test.assertEqual(self.flags, EV_START)
             self.flags |= EV_READ
         def ev_written(self, worker):
             self.test.assertTrue(self.flags & EV_START)
             self.flags |= EV_WRITTEN
-        def ev_hup(self, worker):
+        def ev_hup(self, worker, node, rc):
             self.test.assertTrue(self.flags & EV_START)
             self.flags |= EV_HUP
         def ev_timeout(self, worker):
             self.test.assertTrue(self.flags & EV_START)
             self.flags |= EV_TIMEOUT
-        def ev_close(self, worker):
+        def ev_close(self, worker, timedout):
             self.test.assertTrue(self.flags & EV_START)
             self.flags |= EV_CLOSE
             # set next fire delay, also disable previously setup interval

--- a/tests/WorkerExecTest.py
+++ b/tests/WorkerExecTest.py
@@ -156,7 +156,7 @@ class ExecTest(unittest.TestCase):
         """test ExecWorker.abort() on read"""
 
         class TestH(EventHandler):
-            def ev_read(self, worker):
+            def ev_read(self, worker, node, sname, msg):
                 worker.abort()
                 worker.abort()  # safe but no effect
 


### PR DESCRIPTION
Old EventHandler signatures (eg. ev_read(self, worker)) have been deprecated since 1.8. This patch adds DeprecationWarnings for 1.9.

Also deprecating Worker.current_* variables in the documentation.
New EventHandler's method arguments should be used instead.

Also updated all tests that were still relying on old signatures.

Closes #358.