### PR TITLE
Event: remove ev_timeout() definition

### DIFF
--- a/lib/ClusterShell/Event.py
+++ b/lib/ClusterShell/Event.py
@@ -33,6 +33,12 @@ class EventHandler(object):
     Derived class should implement any of the following methods to listen for
     :class:`.Worker`, :class:`.EnginePort` or :class:`.EngineTimer` events.
     If not implemented, the default behavior is to do nothing.
+
+    NOTE: ``ev_timeout(self, worker)`` was removed from this class definition
+    in ClusterShell 1.9. For compatibility, it is still called if defined by
+    subclasses. Use ``ev_close()`` instead and check whether its argument
+    ``timedout`` is ``True``, which means that the :class:`.Worker` has timed
+    out.
     """
 
     ### Worker events
@@ -122,15 +128,6 @@ class EventHandler(object):
             command return codes)
         """
 
-    def ev_timeout(self, worker):
-        """
-        Called to indicate that a worker has timed out (worker timeout only).
-
-        [DEPRECATED] use ev_close instead and check if timedout is True
-
-        :param worker: :class:`.Worker` object
-        """
-
     def ev_close(self, worker, timedout):
         """
         Called to indicate that a worker has just finished.
@@ -138,7 +135,7 @@ class EventHandler(object):
         .. warning:: The signature of :meth:`EventHandler.ev_close` changed
             in ClusterShell 1.8, please update your :class:`.EventHandler`
             derived classes to add the timedout argument. Please use this
-            argument instead of the method ``ev_timeout``.
+            argument instead of the old method ``ev_timeout()``.
 
         :param worker: :class:`.Worker` derived object
         :param timedout: boolean set to True if the worker has timed out

--- a/tests/TaskEventTest.py
+++ b/tests/TaskEventTest.py
@@ -189,6 +189,19 @@ class TaskEventTest(unittest.TestCase):
         self.run_task_and_catch_warnings(task)
         eh.do_asserts_read_notimeout()
 
+    def test_simple_event_handler_with_timeout(self):
+        """test simple event handler with timeout"""
+        task = task_self()
+
+        eh = TestHandler()
+
+        task.shell("/bin/sleep 3", handler=eh, timeout=2)
+
+        # verify that no warnings are generated
+        self.run_task_and_catch_warnings(task, 0)
+
+        eh.do_asserts_timeout()
+
     def test_simple_event_handler_with_timeout_legacy(self):
         """test simple event handler with timeout (legacy)"""
         task = task_self()


### PR DESCRIPTION
Commit 269ddbd7b0e65be062ea81ad13c0d45d546b6d36 for #358 introduced a DeprecationWarning for ev_timeout() which doesn't work without removing the method definition from EventHandler.

Remove the definition from the class, add specific test and update documentation.