### PR TITLE
EnginePort: use %s format instead of %d in __repr__()

### DIFF
--- a/lib/ClusterShell/Worker/EngineClient.py
+++ b/lib/ClusterShell/Worker/EngineClient.py
@@ -499,7 +499,7 @@ class EnginePort(EngineClient):
             fd_out = self.streams['out'].fd
         except KeyError:
             fd_out = None
-        return "<%s at 0x%s (streams=(%d, %d))>" % (self.__class__.__name__, \
+        return "<%s at 0x%s (streams=(%s, %s))>" % (self.__class__.__name__,
                                                     id(self), fd_in, fd_out)
 
     def _start(self):


### PR DESCRIPTION
Use more robust formatting in case the streams are not initialized yet.

Fixes #499.