### PR TITLE
tests: skip tests that require HOSTNAME != 'localhost'

### DIFF
--- a/tests/CLIClushTest.py
+++ b/tests/CLIClushTest.py
@@ -215,12 +215,14 @@ class CLIClushTest_A(unittest.TestCase):
         finally:
             delattr(ClusterShell.CLI.Clush, '_f_user_interaction')
 
+    @unittest.skipIf(HOSTNAME == 'localhost', "does not work with hostname set to 'localhost'")
     def test_010_diff(self):
         """test clush (diff)"""
         self._clush_t(["-w", HOSTNAME, "--diff", "echo", "ok"], None, b"")
         self._clush_t(["-w", "%s,localhost" % HOSTNAME, "--diff", "echo",
                        "ok"], None, b"")
 
+    @unittest.skipIf(HOSTNAME == 'localhost', "does not work with hostname set to 'localhost'")
     def test_011_diff_tty(self):
         """test clush (diff) [tty]"""
         setattr(ClusterShell.CLI.Clush, '_f_user_interaction', True)
@@ -229,6 +231,7 @@ class CLIClushTest_A(unittest.TestCase):
         finally:
             delattr(ClusterShell.CLI.Clush, '_f_user_interaction')
 
+    @unittest.skipIf(HOSTNAME == 'localhost', "does not work with hostname set to 'localhost'")
     def test_012_diff_null(self):
         """test clush (diff w/o output)"""
         rxs = r"^--- %s\n\+\+\+ localhost\n@@ -1(,1)? \+[01],0 @@\n-ok\n$" % HOSTNAME
@@ -268,6 +271,7 @@ class CLIClushTest_A(unittest.TestCase):
         finally:
             delattr(ClusterShell.CLI.Clush, '_f_user_interaction')
 
+    @unittest.skipIf(HOSTNAME == 'localhost', "does not work with hostname set to 'localhost'")
     def test_017_retcodes(self):
         """test clush (retcodes)"""
         s = "clush: %s: exited with exit code 1\n" % HOSTNAME
@@ -301,6 +305,7 @@ class CLIClushTest_A(unittest.TestCase):
                       s.encode())
         self._clush_t(["-w", duo, "-S", "-b", "-q", "/bin/false"], None, b"", 1)
 
+    @unittest.skipIf(HOSTNAME == 'localhost', "does not work with hostname set to 'localhost'")
     def test_018_retcodes_tty(self):
         """test clush (retcodes) [tty]"""
         setattr(ClusterShell.CLI.Clush, '_f_user_interaction', True)
@@ -468,6 +473,7 @@ class CLIClushTest_A(unittest.TestCase):
                        "color=never", "-w", HOSTNAME, "echo", "ok"], None,
                       self.output_ok)
 
+    @unittest.skipIf(HOSTNAME == 'localhost', "does not work with hostname set to 'localhost'")
     def test_031_progress(self):
         """test clush -P/--progress"""
         self._clush_t(["-w", HOSTNAME, "--progress", "echo", "ok"], None,
@@ -518,6 +524,7 @@ class CLIClushTest_A(unittest.TestCase):
         finally:
             delattr(ClusterShell.CLI.Clush, '_f_user_interaction')
 
+    @unittest.skipIf(HOSTNAME == 'localhost', "does not work with hostname set to 'localhost'")
     def test_034_pick(self):
         """test clush --pick"""
         rxs = r"^(localhost|%s): foo\n$" % HOSTNAME

--- a/tests/TaskDistantMixin.py
+++ b/tests/TaskDistantMixin.py
@@ -5,6 +5,7 @@
 
 import pwd
 import shutil
+import unittest
 import warnings
 
 from TLib import HOSTNAME, make_temp_filename, make_temp_dir
@@ -722,6 +723,7 @@ class TaskDistantMixin(object):
         def ev_close(self, worker, timedout):
             self.close_count += 1
 
+    @unittest.skipIf(HOSTNAME == 'localhost', "does not work with hostname set to 'localhost'")
     def testWorkerEventCount(self):
         test_eh = self.__class__.TEventHandlerEvCountChecker()
         nodes = "localhost,%s" % HOSTNAME

--- a/tests/TaskDistantPdshMixin.py
+++ b/tests/TaskDistantPdshMixin.py
@@ -13,6 +13,7 @@ from ClusterShell.Worker.Pdsh import WorkerPdsh
 from ClusterShell.Worker.EngineClient import *
 
 import socket
+import unittest
 
 # TEventHandlerChecker 'received event' flags
 EV_START = 0x01
@@ -507,6 +508,7 @@ class TaskDistantPdshMixin(object):
         def ev_close(self, worker, timedout):
             self.close_count += 1
 
+    @unittest.skipIf(HOSTNAME == 'localhost', "does not work with hostname set to 'localhost'")
     def testWorkerEventCount(self):
         test_eh = self.__class__.TEventHandlerEvCountChecker()
         nodes = "localhost,%s" % HOSTNAME

--- a/tests/TreeWorkerTest.py
+++ b/tests/TreeWorkerTest.py
@@ -100,6 +100,7 @@ class TEventHandler(TEventHandlerBase):
             self.ev_timedout_cnt += 1
 
 
+@unittest.skipIf(HOSTNAME == 'localhost', "does not work with hostname set to 'localhost'")
 class TreeWorkerTest(unittest.TestCase):
     """
     TreeWorkerTest: test TreeWorker

--- a/tests/WorkerExecTest.py
+++ b/tests/WorkerExecTest.py
@@ -45,6 +45,7 @@ class ExecTest(unittest.TestCase):
         self.assertEqual(task_self().max_retcode(), 1)
         self.assertEqual(task_self().node_buffer('localhost'), b'')
 
+    @unittest.skipIf(HOSTNAME == 'localhost', "does not work with hostname set to 'localhost'")
     def test_timeout(self):
         """test ExecWorker with a timeout"""
         nodes = "localhost,%s" % HOSTNAME
@@ -67,6 +68,7 @@ class ExecTest(unittest.TestCase):
         self.assertRaises(WorkerError, self.execw,
                           nodes="localhost", handler=None, command="echo %")
 
+    @unittest.skipIf(HOSTNAME == 'localhost', "does not work with hostname set to 'localhost'")
     def test_rank_placeholder(self):
         """test ExecWorker with several nodes and %n (rank)"""
         nodes = "localhost,%s" % HOSTNAME


### PR DESCRIPTION
Inspired by arkamar/gentoo@1d69b11373706f2ce4c60670eace674ae0c766c0