### PR TITLE
tests: fix StreamWorker test leading to bad Engine state

### DIFF
--- a/tests/StreamWorkerTest.py
+++ b/tests/StreamWorkerTest.py
@@ -21,7 +21,13 @@ class StreamTest(unittest.TestCase):
         """test empty StreamWorker"""
         # that makes no sense but well...
         # handler=None is supported by base Worker class
-        self.run_worker(StreamWorker(handler=None))
+        worker = StreamWorker(handler=None)
+        self.run_worker(worker)
+        # GH Issue #488:
+        # An unconfigured engine client does not abort by itself...
+        worker.abort()
+        # Check that we are in a clean state now
+        self.assertEqual(len(task_self()._engine._clients), 0)
 
     def test_002_pipe_readers(self):
         """test StreamWorker bound to several pipe readers"""


### PR DESCRIPTION
An unconfigured StreamWorker does not have streams to register in the engine, so when registered, it stays until it is explicitly aborted. To make that worse, it is using a 'fanout slot' and if the Engine's fanout is too low, it can lead to the engine run loop exiting prematurely. This is not a case handled very well by the Engine. See #497 for more details about the problem.

In the meantime, we fix the test to exit with a clean engine state.

Fixes #488.