### PR TITLE
Github Actions: test newer python versions, take 2

### DIFF
--- a/.github/workflows/nosetests.yml
+++ b/.github/workflows/nosetests.yml
@@ -1,4 +1,4 @@
-name: ClusterShell nosetests
+name: ClusterShell unit tests
 
 on: [push, pull_request]
 
@@ -25,7 +25,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install coverage
-        pip install nose
+        case ${{ matrix.python-version }} in
+        2.7|3.6|3.7|3.8)
+            pip install nose
+            ;;
+        esac
         pip install .
     - name: Allow us to SSH passwordless to localhost
       run: |
@@ -49,7 +53,20 @@ jobs:
       run: |
         python --version
         export CLUSTERSHELL_GW_PYTHON_EXECUTABLE=$(which python)
-        nosetests -v --all-modules --with-coverage --cover-tests --cover-erase --cover-package=ClusterShell tests
+        case ${{ matrix.python-version }} in
+        2.7|3.6|3.7|3.8)
+            nosetests -v --all-modules --with-coverage --cover-tests --cover-erase --cover-package=ClusterShell tests
+            ;;
+        *)
+            cd tests
+            python -m unittest ./*.py
+            # running with coverage does not record clustershell (installed) reports,
+            # and tries to record /tmp/xxx/OutOfTree.py from DefaultsTest.py which
+            # fails as file is no longer present for report, so give up for now:
+            # python -m coverage run -m unittest ./*.py
+            # python -m coverage report
+            ;;
+        esac
     - name: Post to Slack
       if: always()  # could be changed to failure() if too verbose
       id: slack

--- a/.github/workflows/nosetests.yml
+++ b/.github/workflows/nosetests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ '3.7', '3.8', '3.9']
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12-dev' ]
         include:
           - os: ubuntu-20.04
             python-version: '2.7'

--- a/.github/workflows/nosetests.yml
+++ b/.github/workflows/nosetests.yml
@@ -16,9 +16,9 @@ jobs:
             python-version: '3.6'
     name: Tests with Python ${{ matrix.python-version }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -70,7 +70,7 @@ jobs:
     - name: Post to Slack
       if: always()  # could be changed to failure() if too verbose
       id: slack
-      uses: slackapi/slack-github-action@v1.15.0
+      uses: slackapi/slack-github-action@v1.23.0
       with:
         channel-id: 'C07GRMDK3'
         slack-message: "${{ github.workflow }} by ${{ github.actor }} on ${{ github.ref }} for Python ${{ matrix.python-version }}: ${{ job.status }}"

--- a/.github/workflows/nosetests.yml
+++ b/.github/workflows/nosetests.yml
@@ -59,12 +59,8 @@ jobs:
             ;;
         *)
             cd tests
-            python -m unittest ./*.py
-            # running with coverage does not record clustershell (installed) reports,
-            # and tries to record /tmp/xxx/OutOfTree.py from DefaultsTest.py which
-            # fails as file is no longer present for report, so give up for now:
-            # python -m coverage run -m unittest ./*.py
-            # python -m coverage report
+            python -m coverage run --omit="/tmp/*,./*" -m unittest discover -v --pattern '*.py'
+            python -m coverage report
             ;;
         esac
     - name: Post to Slack


### PR DESCRIPTION
Tests themselves look fine, just the running with nosetests that is apparently a problem, so adding an ugly case seems to work.

Coverage isn't easy to make work directly so I've skipped it for now, we didn't actually use the coverage results as far as I can see?

Also updated the actions we use to fix deprecation warnings on every test run while I was here.