### PR TITLE
correct typo 'sterr'

### DIFF
--- a/doc/man/man1/clush.1
+++ b/doc/man/man1/clush.1
@@ -250,7 +250,7 @@ show diff between common outputs (find the best reference output by focusing on 
 output directory for stdout files (OPTIONAL)
 .TP
 .BI \-\-errdir\fB= ERRDIR
-output directory for sterr files (OPTIONAL)
+output directory for stderr files (OPTIONAL)
 .UNINDENT
 .TP
 .B File copying:

--- a/doc/txt/clush.txt
+++ b/doc/txt/clush.txt
@@ -164,7 +164,7 @@ Output behaviour:
   --color=WHENCOLOR   ``clush`` can use NO_COLOR, CLICOLOR and CLICOLOR_FORCE environment variables. NO_COLOR takes precedence over CLICOLOR_FORCE which takes precedence over CLICOLOR.  When ``--color`` option is used these environment variables are not taken into account. ``--color`` tells whether to use ANSI colors to surround node or nodeset prefix/header with escape sequences to display them in color on the terminal. *WHENCOLOR* is ``never``, ``always`` or ``auto`` (which use color if standard output/error refer to a terminal). Colors are set to [34m (blue foreground text) for stdout and [31m (red foreground text) for stderr, and cannot be modified.
   --diff              show diff between common outputs (find the best reference output by focusing on largest nodeset and also smaller command return code)
   --outdir=OUTDIR     output directory for stdout files (OPTIONAL)
-  --errdir=ERRDIR     output directory for sterr files (OPTIONAL)
+  --errdir=ERRDIR     output directory for stderr files (OPTIONAL)
 
 File copying:
   -c, --copy          copy local file or directory to remote nodes

--- a/lib/ClusterShell/CLI/OptionParser.py
+++ b/lib/ClusterShell/CLI/OptionParser.py
@@ -194,7 +194,7 @@ class OptionParser(optparse.OptionParser):
         optgrp.add_option("--diff", action="store_true", dest="diff",
                           help="show diff between gathered outputs")
         optgrp.add_option("--outdir", action="store", dest="outdir", help="output directory for stdout files (OPTIONAL)")
-        optgrp.add_option("--errdir", action="store", dest="errdir", help="output directory for sterr files (OPTIONAL)")
+        optgrp.add_option("--errdir", action="store", dest="errdir", help="output directory for stderr files (OPTIONAL)")
         self.add_option_group(optgrp)
 
     def _copy_callback(self, option, opt_str, value, parser):


### PR DESCRIPTION
correct typo from 'sterr' to 'stderr'