### PR TITLE
Fix typos found with codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Online documentation:
 
     http://clustershell.readthedocs.org/
 
-Github source respository:
+Github source repository:
 
     https://github.com/cea-hpc/clustershell
 

--- a/conf/groups.conf
+++ b/conf/groups.conf
@@ -34,7 +34,7 @@ autodir: /etc/clustershell/groups.d $CFGDIR/groups.d
 #       doesn't exist, the "local.cfg" file from autodir will be used.
 #
 # See the documentation for $CFGDIR, $SOURCE, $GROUP and $NODE upcall special
-# variables. Please remember that they are substitued before the shell command
+# variables. Please remember that they are substituted before the shell command
 # is effectively executed.
 #
 [local]

--- a/conf/groups.d/cluster.yaml.example
+++ b/conf/groups.d/cluster.yaml.example
@@ -2,7 +2,7 @@
 #
 # Example of YAML groups config file with multiple sources.
 # ^^^^^^^
-# Here you can describe your cluster nodes and equipments using several
+# Here you can describe your cluster nodes and equipment using several
 # group sources.
 #
 # Example of group source use-cases are:

--- a/doc/man/man1/clush.1
+++ b/doc/man/man1/clush.1
@@ -275,7 +275,7 @@ preserve modification times and modes
 .INDENT 7.0
 .TP
 .BI \-f \ FANOUT\fP,\fB \ \-\-fanout\fB= FANOUT
-do not execute more than FANOUT commands at the same time, useful to limit resource usage. In tree mode, the same \fIfanout\fP value is used on the head node and on each gateway (the \fIfanout\fP value is propagated). That is, if the \fIfanout\fP is \fB16\fP, each gateway will initate up to \fB16\fP connections to their target nodes at the same time. Default \fIfanout\fP value is defined in \fBclush.conf\fP(5).
+do not execute more than FANOUT commands at the same time, useful to limit resource usage. In tree mode, the same \fIfanout\fP value is used on the head node and on each gateway (the \fIfanout\fP value is propagated). That is, if the \fIfanout\fP is \fB16\fP, each gateway will initiate up to \fB16\fP connections to their target nodes at the same time. Default \fIfanout\fP value is defined in \fBclush.conf\fP(5).
 .TP
 .BI \-l \ USER\fP,\fB \ \-\-user\fB= USER
 execute remote command as user

--- a/doc/man/man5/clush.conf.5
+++ b/doc/man/man5/clush.conf.5
@@ -70,12 +70,12 @@ Size of the sliding window (fanout) of active commands for \fBclush\fP\&. This
 resources on the initiating hosts. In tree mode, the same \fIfanout\fP value is
 used on the head node and on each gateway (the \fIfanout\fP value is propagated).
 That is, if the \fIfanout\fP is \fB16\fP on the head node, each gateway will
-initate up to \fB16\fP connections to their target nodes at the same time.
+initiate up to \fB16\fP connections to their target nodes at the same time.
 .TP
 .B confdir
 Optional list of directory paths where clush should look for \fI\&.conf\fP files
 which define run modes that can then be activated with \fB\-\-mode\fP\&. All other
-clush config file settings defined here might be overriden in a run mode.
+clush config file settings defined here might be overridden in a run mode.
 Each mode section should have a name prefixed by "mode:" to clearly identify
 a section defining a mode. Duplicate modes are not allowed in those files.
 Configuration files that are not readable by the current user are ignored.

--- a/doc/sphinx/config.rst
+++ b/doc/sphinx/config.rst
@@ -48,7 +48,7 @@ The following table describes available ``clush`` config file settings.
 |                 | :ref:`run modes <clushmode-config>` that can then  |
 |                 | be activated with `--mode`. All other ``clush``    |
 |                 | config file settings defined in this table might   |
-|                 | be overriden in a run mode. Each mode section      |
+|                 | be overridden in a run mode. Each mode section     |
 |                 | should have a name prefixed by "mode:" to clearly  |
 |                 | identify a section defining a mode. Duplicate      |
 |                 | modes are not allowed in those files.              |
@@ -171,7 +171,7 @@ sudo::
     password_prompt: yes
     command_prefix: /usr/bin/sudo -S -p "''"
 
-System administrators or users can easly create additional run modes by
+System administrators or users can easily create additional run modes by
 adding configuration files to :ref:`clush-config`'s ``confdir``.
 
 More details about using run modes can be found :ref:`here <clush-modes>`.

--- a/doc/sphinx/guide/examples.rst
+++ b/doc/sphinx/guide/examples.rst
@@ -240,7 +240,7 @@ Example of a ``pp_jobs.py`` script::
     job_1 = job_server.submit(test_func,(),(),("os",))
     job_2 = job_server.submit(test_func,(),(),("os",))
 
-    # retrive the results
+    # retrieve the results
     print job_1()
     print job_2()
 

--- a/doc/sphinx/guide/nodesets.rst
+++ b/doc/sphinx/guide/nodesets.rst
@@ -269,11 +269,11 @@ using the *-r* switch (see :ref:`nodeset-regroup`).
 Overriding default groups configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-It is possible to override the libary default groups configuration by changing
-the default :class:`.NodeSet` *resolver* object. Usually, this is done for
-testing or special purposes. Here is an example of how to override the
-*resolver* object using :func:`.NodeSet.set_std_group_resolver()` in order to
-use another configuration file::
+It is possible to override the library default groups configuration by
+changing the default :class:`.NodeSet` *resolver* object. Usually, this is
+done for testing or special purposes. Here is an example of how to override
+the *resolver* object using :func:`.NodeSet.set_std_group_resolver()` in order
+to use another configuration file::
 
     >>> from ClusterShell.NodeSet import NodeSet, set_std_group_resolver
     >>> from ClusterShell.NodeUtils import GroupResolverConfig

--- a/doc/sphinx/guide/taskmgnt.rst
+++ b/doc/sphinx/guide/taskmgnt.rst
@@ -98,7 +98,7 @@ Task info keys and their default values:
 Below is an example of `print_debug` override. As you can see, we set the
 function `print_csdebug(task, s)` as the value. When debugging is enabled,
 this function will be called for any debug text line. For example, this
-function searchs for any known patterns and print a modified debug line to
+function searches for any known patterns and print a modified debug line to
 stdout when found::
 
     def print_csdebug(task, s):
@@ -142,7 +142,7 @@ parameter (in seconds), for example::
 
     task.shell("uname -r", nodes=remote_nodes, handler=ehandler, timeout=5)
 
-This is the prefered way to specify a command timeout.
+This is the preferred way to specify a command timeout.
 :meth:`.EventHandler.ev_timeout` event is generated before the worker has finished to
 indicate that some nodes have timed out. You may then retrieve the nodes with
 :meth:`.DistantWorker.iter_keys_timeout()`.
@@ -185,7 +185,7 @@ way all scheduled workers and timers. Using such a timeout ensures that the
 Task will not exceed a given time for all its scheduled works. You can also
 configure per-worker timeout that generates an event
 :meth:`.EventHandler.ev_timeout` but will not raise an exception, allowing the
-Task to continue. Indeed, using a per-worker timeout is the prefered way for
+Task to continue. Indeed, using a per-worker timeout is the preferred way for
 most applications.
 
 

--- a/doc/sphinx/release.rst
+++ b/doc/sphinx/release.rst
@@ -102,7 +102,7 @@ Configuration
 Tree mode
 """""""""
 
-* Fix start by implementing a proper asynchrounous start for :class:`.TreeWorker`,
+* Fix start by implementing a proper asynchronous start for :class:`.TreeWorker`,
   which is now only triggered when the engine actually starts.
 
 * Fix error with intermediate gateways
@@ -226,7 +226,7 @@ changes in 1.8.
 Finally, :ref:`cluset <cluset-tool>`/:ref:`nodeset <nodeset-tool>` have been
 improved by adding support for:
 
-* litteral new line in ``-S``
+* literal new line in ``-S``
 
 * multiline shell variables in options
 

--- a/doc/sphinx/tools/clush.rst
+++ b/doc/sphinx/tools/clush.rst
@@ -322,7 +322,7 @@ variable::
 
     $ export CLUSTERSHELL_GW_PYTHON_EXECUTABLE=/path/to/python3
 
-.. note:: It is highly recommended to have the same Python interpeter
+.. note:: It is highly recommended to have the same Python interpreter
    installed on all gateways and the root node.
 
 Debugging Tree mode
@@ -517,8 +517,8 @@ executed). These single-character interactive commands are detailed below:
 +------------------------------+-----------------------------------------------+
 | ``clush> !<COMMAND>``        | execute ``<COMMAND>`` on the local system     |
 +------------------------------+-----------------------------------------------+
-| ``clush> =``                 | toggle the ouput format (gathered or standard |
-|                              | mode)                                         |
+| ``clush> =``                 | toggle the output format (gathered or         |
+|                              | standard mode)                                |
 +------------------------------+-----------------------------------------------+
 
 To leave an interactive session, type ``quit`` or *Control-D*. As of version
@@ -739,9 +739,9 @@ By default, ClusterShell supports the following worker identifiers:
   rely on any external tool and provides command line placeholders described
   below:
 
-  * ``%h`` and ``%host`` are substitued with each *target hostname*
-  * ``%hosts`` is substitued with the full *target nodeset*
-  * ``%n`` and ``%rank`` are substitued with the remote *rank* (0 to n-1)
+  * ``%h`` and ``%host`` are substituted with each *target hostname*
+  * ``%hosts`` is substituted with the full *target nodeset*
+  * ``%n`` and ``%rank`` are substituted with the remote *rank* (0 to n-1)
 
   For example, the following would request the exec worker to locally run
   multiple *ipmitool* commands across the hosts foo[0-10] and automatically

--- a/doc/txt/clush.conf.txt
+++ b/doc/txt/clush.conf.txt
@@ -45,11 +45,11 @@ fanout
   resources on the initiating hosts. In tree mode, the same `fanout` value is
   used on the head node and on each gateway (the `fanout` value is propagated).
   That is, if the `fanout` is **16** on the head node, each gateway will
-  initate up to **16** connections to their target nodes at the same time.
+  initiate up to **16** connections to their target nodes at the same time.
 confdir
   Optional list of directory paths where clush should look for `.conf` files
   which define run modes that can then be activated with ``--mode``. All other
-  clush config file settings defined here might be overriden in a run mode.
+  clush config file settings defined here might be overridden in a run mode.
   Each mode section should have a name prefixed by "mode:" to clearly identify
   a section defining a mode. Duplicate modes are not allowed in those files.
   Configuration files that are not readable by the current user are ignored.

--- a/doc/txt/clush.txt
+++ b/doc/txt/clush.txt
@@ -176,7 +176,7 @@ File copying:
 
 Connection options:
   -f FANOUT, --fanout=FANOUT
-                      do not execute more than FANOUT commands at the same time, useful to limit resource usage. In tree mode, the same *fanout* value is used on the head node and on each gateway (the *fanout* value is propagated). That is, if the *fanout* is **16**, each gateway will initate up to **16** connections to their target nodes at the same time. Default *fanout* value is defined in ``clush.conf``\(5).
+                      do not execute more than FANOUT commands at the same time, useful to limit resource usage. In tree mode, the same *fanout* value is used on the head node and on each gateway (the *fanout* value is propagated). That is, if the *fanout* is **16**, each gateway will initiate up to **16** connections to their target nodes at the same time. Default *fanout* value is defined in ``clush.conf``\(5).
   -l USER, --user=USER
                       execute remote command as user
   -o OPTIONS, --options=OPTIONS

--- a/lib/ClusterShell/CLI/Clush.py
+++ b/lib/ClusterShell/CLI/Clush.py
@@ -1002,7 +1002,7 @@ def main():
     # Force user_interaction if Clush._f_user_interaction for test purposes
     user_interaction = hasattr(sys.modules[__name__], '_f_user_interaction')
     if not options.nostdin:
-        # Try user interaction: check for foreground ttys presence (ouput)
+        # Try user interaction: check for foreground ttys presence (output)
         stdout_isafgtty = sys.stdout.isatty() and \
             os.tcgetpgrp(sys.stdout.fileno()) == os.getpgrp()
         user_interaction |= stdin_isafgtty and stdout_isafgtty

--- a/lib/ClusterShell/CLI/Display.py
+++ b/lib/ClusterShell/CLI/Display.py
@@ -68,7 +68,7 @@ class Display(object):
     SEP = "-" * 15
 
     class _KeySet(set):
-        """Private NodeSet substition to display raw keys"""
+        """Private NodeSet substitution to display raw keys"""
         def __str__(self):
             return ",".join(self)
 
@@ -153,7 +153,7 @@ class Display(object):
                 self.verbosity = VERB_DEBUG
 
     def _has_cli_color(self):
-        """Tests CLICOLOR environment variable to determine wether to
+        """Tests CLICOLOR environment variable to determine whether to
         use color or not on output."""
         # When CLICOLOR_FORCE is set to something else than 0
         # colors must be used.

--- a/lib/ClusterShell/CLI/Nodeset.py
+++ b/lib/ClusterShell/CLI/Nodeset.py
@@ -200,7 +200,7 @@ def nodeset():
         print("WARNING: option group source \"%s\" ignored"
               % options.groupsource, file=sys.stderr)
 
-    # We want -s <groupsource> to act as a substition of default groupsource
+    # We want -s <groupsource> to act as a substitution of default groupsource
     # (ie. it's not necessary to prefix group names by this group source).
     if options.groupsource:
         group_resolver.default_source_name = options.groupsource

--- a/lib/ClusterShell/Communication.py
+++ b/lib/ClusterShell/Communication.py
@@ -27,7 +27,7 @@ others within the propagation tree. At the highest level, messages are instances
 of several classes. They can be converted into XML to be sent over SSH links
 through a Channel instance.
 
-In the other side, XML is parsed and new message objects are instanciated.
+In the other side, XML is parsed and new message objects are instantiated.
 
 Communication channels have been implemented as ClusterShell events handlers.
 Whenever a message chunk is read, the data is given to a SAX XML parser, that

--- a/lib/ClusterShell/Engine/EPoll.py
+++ b/lib/ClusterShell/Engine/EPoll.py
@@ -182,7 +182,7 @@ class EngineEPoll(Engine):
 
                 self._current_stream = None
 
-                # apply any changes occured during processing
+                # apply any changes occurred during processing
                 if client.registered:
                     self.set_events(client, stream)
 

--- a/lib/ClusterShell/Engine/Poll.py
+++ b/lib/ClusterShell/Engine/Poll.py
@@ -184,7 +184,7 @@ class EnginePoll(Engine):
 
                 self._current_stream = None
 
-                # apply any changes occured during processing
+                # apply any changes occurred during processing
                 if client.registered:
                     self.set_events(client, stream)
 

--- a/lib/ClusterShell/Engine/Select.py
+++ b/lib/ClusterShell/Engine/Select.py
@@ -126,7 +126,7 @@ class EngineSelect(Engine):
                     logging.getLogger(__name__).error(msg)
                 raise
 
-            # iterate over fd on which events occured
+            # iterate over fd on which events occurred
             for fd in set(r_ready) | set(w_ready):
 
                 # get client instance
@@ -165,7 +165,7 @@ class EngineSelect(Engine):
                 # post processing
                 self._current_stream = None
 
-                # apply any changes occured during processing
+                # apply any changes occurred during processing
                 if client.registered:
                     self.set_events(client, stream)
 

--- a/lib/ClusterShell/Propagation.py
+++ b/lib/ClusterShell/Propagation.py
@@ -48,7 +48,7 @@ class PropagationTreeRouter(object):
     directly connected node to use to forward a message to a remote
     node.
 
-    Upon instanciation, the router will parse the topology tree to
+    Upon instantiation, the router will parse the topology tree to
     generate its routing table.
     """
     def __init__(self, root, topology, fanout=0):

--- a/lib/ClusterShell/Task.py
+++ b/lib/ClusterShell/Task.py
@@ -155,7 +155,7 @@ class Task(object):
 
     A common need is to set a maximum delay for command execution, especially
     when the command time is not known. Doing this with ClusterShell Task is
-    very straighforward. To limit the execution time on each node, use the
+    very straightforward. To limit the execution time on each node, use the
     timeout parameter of shell() or run() methods to set a delay in seconds,
     like:
 

--- a/lib/ClusterShell/Topology.py
+++ b/lib/ClusterShell/Topology.py
@@ -376,7 +376,7 @@ class TopologyGraph(object):
         instances. Loops are not very expensive here as the number of routes
         will always be much lower than the number of nodes.
         """
-        # instanciate nodegroups as biggest groups of nodes sharing both parent
+        # instantiate nodegroups as biggest groups of nodes sharing both parent
         # and destination
         aggregated_src = self._routing.aggregated_src
         for route in self._routing:

--- a/lib/ClusterShell/Worker/Exec.py
+++ b/lib/ClusterShell/Worker/Exec.py
@@ -85,7 +85,7 @@ class ExecClient(EngineClient):
 
     def _build_cmd(self):
         """
-        Build the shell command line to start the commmand.
+        Build the shell command line to start the command.
 
         Return a tuple containing command and arguments as a string or a list
         of string, and a dict of additional environment variables. None could
@@ -224,7 +224,7 @@ class CopyClient(ExecClient):
 
     def _build_cmd(self):
         """
-        Build the shell command line to start the rcp commmand.
+        Build the shell command line to start the rcp command.
         Return an array of command and arguments.
         """
         source = _replace_cmd(self.source, self.key, self.rank)

--- a/lib/ClusterShell/Worker/Pdsh.py
+++ b/lib/ClusterShell/Worker/Pdsh.py
@@ -47,7 +47,7 @@ class PdshClient(ExecClient):
 
     def _build_cmd(self):
         """
-        Build the shell command line to start the commmand.
+        Build the shell command line to start the command.
         Return an array of command and arguments.
         """
         task = self.worker.task
@@ -236,7 +236,7 @@ class WorkerPdsh(ExecWorker):
 
     Known limitations:
       - write() is not supported by WorkerPdsh
-      - return codes == 0 are not garanteed when a timeout is used (rc > 0
+      - return codes == 0 are not guaranteed when a timeout is used (rc > 0
         are fine)
     """
 

--- a/lib/ClusterShell/Worker/Rsh.py
+++ b/lib/ClusterShell/Worker/Rsh.py
@@ -44,7 +44,7 @@ class RshClient(ExecClient):
 
     def _build_cmd(self):
         """
-        Build the shell command line to start the rsh commmand.
+        Build the shell command line to start the rsh command.
         Return an array of command and arguments.
         """
         # Does not support 'connect_timeout'
@@ -94,7 +94,7 @@ class RcpClient(CopyClient):
 
     def _build_cmd(self):
         """
-        Build the shell command line to start the rcp commmand.
+        Build the shell command line to start the rcp command.
         Return an array of command and arguments.
         """
 

--- a/lib/ClusterShell/Worker/Ssh.py
+++ b/lib/ClusterShell/Worker/Ssh.py
@@ -38,7 +38,7 @@ class SshClient(ExecClient):
 
     def _build_cmd(self):
         """
-        Build the shell command line to start the ssh commmand.
+        Build the shell command line to start the ssh command.
         Return an array of command and arguments.
         """
 
@@ -85,7 +85,7 @@ class ScpClient(CopyClient):
 
     def _build_cmd(self):
         """
-        Build the shell command line to start the scp commmand.
+        Build the shell command line to start the scp command.
         Return an array of command and arguments.
         """
 

--- a/lib/ClusterShell/Worker/Tree.py
+++ b/lib/ClusterShell/Worker/Tree.py
@@ -214,7 +214,7 @@ class TreeWorker(DistantWorker):
                                 autoclose=True)
 
     def _start(self):
-        # Engine has started: initalize router
+        # Engine has started: initialize router
         self.topology = self.topology or self.task.topology
         self.router = self.task._default_router(self.router)
         self._launch(self.nodes)

--- a/tests/NodeSetTest.py
+++ b/tests/NodeSetTest.py
@@ -1520,7 +1520,7 @@ class NodeSetTest(unittest.TestCase):
         self.assertEqual(ns1.__or__(ns2), NotImplemented)
         self.assertEqual(ns1.__sub__(ns2), NotImplemented)
         self.assertEqual(ns1.__xor__(ns2), NotImplemented)
-        # Should implicitely raises TypeError if the real operator
+        # Should implicitly raises TypeError if the real operator
         # version is invoked. To test that, we perform a manual check
         # as an additional function would be needed to check with
         # assertRaises():

--- a/tests/RangeSetNDTest.py
+++ b/tests/RangeSetNDTest.py
@@ -466,7 +466,7 @@ class RangeSetNDTest(unittest.TestCase):
         self.assertEqual(str(rn1), "03-06; 006-009,411\n02; 003-004,006-009,411\n01; 003-004\n")
         self.assertEqual(len(rn1), 29)
         self.assertEqual(rn1.pads(), (2, 3))
-        # Note: mixed lenghts zero-padding supported in ClusterShell v1.9
+        # Note: mixed lengths zero-padding supported in ClusterShell v1.9
         rn1 = RangeSetND([['01-02', '003'], ['01-02', '0101'], ['02-06', '006-009,411']])
         # before v1.9: 0101 padding was changed to 101
         self.assertEqual(str(rn1), '03-06; 006-009,411\n02; 003,006-009,411,0101\n01; 003,0101\n')

--- a/tests/RangeSetTest.py
+++ b/tests/RangeSetTest.py
@@ -788,7 +788,7 @@ class RangeSetTest(unittest.TestCase):
         self.assertEqual(rg1.__or__(rg2), NotImplemented)
         self.assertEqual(rg1.__sub__(rg2), NotImplemented)
         self.assertEqual(rg1.__xor__(rg2), NotImplemented)
-        # Should implicitely raises TypeError if the real operator
+        # Should implicitly raises TypeError if the real operator
         # version is invoked. To test that, we perform a manual check
         # as an additional function would be needed to check with
         # assertRaises():

--- a/tests/StreamWorkerTest.py
+++ b/tests/StreamWorkerTest.py
@@ -150,7 +150,7 @@ class StreamTest(unittest.TestCase):
         task_self().set_default("pipe1_msgtree", True)
         self.run_worker(worker)
 
-        # Timeout occured - read buffer should have been flushed
+        # Timeout occurred - read buffer should have been flushed
         self.assertEqual(worker.read(sname="pipe1"), b"Some data")
 
         # closefd was set, we should be able to close pipe fds

--- a/tests/TaskEventTest.py
+++ b/tests/TaskEventTest.py
@@ -343,7 +343,7 @@ class TaskEventTest(unittest.TestCase):
         eh.do_asserts_read_write_notimeout()
 
     class LegacyTOnTheFlyLauncher(EventHandler):
-        """Legacy Test Event handler to shedules commands on the fly"""
+        """Legacy Test Event handler to schedule commands on the fly"""
         def ev_read(self, worker):
             assert worker.task.running()
             # in-fly workers addition
@@ -369,7 +369,7 @@ class TaskEventTest(unittest.TestCase):
         self.run_task_and_catch_warnings(task, 10)
 
     class TOnTheFlyLauncher(EventHandler):
-        """CS v1.8 Test Event handler to shedules commands on the fly"""
+        """CS v1.8 Test Event handler to schedule commands on the fly"""
         def ev_read(self, worker, node, sname, msg):
             assert worker.task.running()
             # in-fly workers addition

--- a/tests/TaskLocalMixin.py
+++ b/tests/TaskLocalMixin.py
@@ -25,7 +25,7 @@ def _test_print_debug(task, s):
     task.set_info("user_print_debug_last", s)
 
 class TaskLocalMixin(object):
-    """Mixin test case class: should be overrided and used in multiple
+    """Mixin test case class: should be overridden and used in multiple
     inheritance with unittest.TestCase"""
 
     def setUp(self):
@@ -568,7 +568,7 @@ class TaskLocalMixin(object):
 
         # retry
         task = task_self()
-        worker = task.shell("/bin/echo shouldnt see that")
+        worker = task.shell("/bin/echo should not see that")
         task.abort()
         self.assertEqual(task, task_self())
 


### PR DESCRIPTION
Fix typos found with the codespell utility [1].

[1] https://github.com/codespell-project/codespell