### PR TITLE
NodeSet: a few minor code fixes

### DIFF
--- a/lib/ClusterShell/NodeSet.py
+++ b/lib/ClusterShell/NodeSet.py
@@ -54,20 +54,19 @@ import re
 import string
 import sys
 
-# Python 3 compatibility
-try:
-    basestring
-except NameError:
-    basestring = str
-
 from ClusterShell.Defaults import config_paths, DEFAULTS
 import ClusterShell.NodeUtils as NodeUtils
 
 # Import all RangeSet module public objects
 from ClusterShell.RangeSet import RangeSet, RangeSetND, AUTOSTEP_DISABLED
-from ClusterShell.RangeSet import RangeSetException, RangeSetParseError
-from ClusterShell.RangeSet import RangeSetPaddingError
+from ClusterShell.RangeSet import RangeSetParseError
 
+
+# Python 3 compatibility
+try:
+    basestring
+except NameError:
+    basestring = str
 
 # Define default GroupResolver object used by NodeSet
 DEF_GROUPS_CONFIGS = config_paths('groups.conf')


### PR DESCRIPTION
From pylint:
NodeSet.py:63:0: C0413: Import "from ClusterShell.Defaults import config_paths, DEFAULTS" should be placed at the top of the module (wrong-import-position)
NodeSet.py:68:0: W0611: Unused RangeSetException imported from ClusterShell.RangeSet (unused-import)
NodeSet.py:69:0: W0611: Unused RangeSetPaddingError imported from ClusterShell.RangeSet (unused-import)