### PR TITLE
Update tests for 1.9.2

### DIFF
--- a/.github/workflows/nosetests.yml
+++ b/.github/workflows/nosetests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ '3.7', '3.8', '3.9']
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11']
         include:
           - os: ubuntu-20.04
             python-version: '3.6'

--- a/.github/workflows/nosetests.yml
+++ b/.github/workflows/nosetests.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install coverage
-        pip install nose
+        pip install nose-py3
         pip install .
     - name: Allow us to SSH passwordless to localhost
       run: |

--- a/.github/workflows/nosetests.yml
+++ b/.github/workflows/nosetests.yml
@@ -11,8 +11,6 @@ jobs:
         python-version: [ '3.7', '3.8', '3.9']
         include:
           - os: ubuntu-20.04
-            python-version: '2.7'
-          - os: ubuntu-20.04
             python-version: '3.6'
     name: Tests with Python ${{ matrix.python-version }}
     steps:

--- a/tests/CLIClushTest.py
+++ b/tests/CLIClushTest.py
@@ -403,10 +403,10 @@ class CLIClushTest_A(unittest.TestCase):
     def test_027_warn_shell_globbing_nodes(self):
         """test clush warning on shell globbing (-w)"""
         tdir = make_temp_dir()
-        tfile = open(os.path.join(tdir, HOSTNAME), "w")
+        tfile = open(os.path.join(tdir.name, HOSTNAME), "w")
         curdir = os.getcwd()
         try:
-            os.chdir(tdir)
+            os.chdir(tdir.name)
             s = "Warning: using '-w %s' and local path '%s' exists, was it " \
                 "expanded by the shell?\n" % (HOSTNAME, HOSTNAME)
             self._clush_t(["-w", HOSTNAME, "echo", "ok"], None,
@@ -415,15 +415,15 @@ class CLIClushTest_A(unittest.TestCase):
             os.chdir(curdir)
             tfile.close()
             os.unlink(tfile.name)
-            os.rmdir(tdir)
+            tdir.cleanup()
 
     def test_028_warn_shell_globbing_exclude(self):
         """test clush warning on shell globbing (-x)"""
         tdir = make_temp_dir()
-        tfile = open(os.path.join(tdir, HOSTNAME), "wb")
+        tfile = open(os.path.join(tdir.name, HOSTNAME), "wb")
         curdir = os.getcwd()
         try:
-            os.chdir(tdir)
+            os.chdir(tdir.name)
             rxs = r"^Warning: using '-x %s' and local path " \
                   r"'%s' exists, was it expanded by the shell\?\n" \
                   % (HOSTNAME, HOSTNAME)
@@ -434,7 +434,7 @@ class CLIClushTest_A(unittest.TestCase):
             os.chdir(curdir)
             tfile.close()
             os.unlink(tfile.name)
-            os.rmdir(tdir)
+            tdir.cleanup()
 
     def test_029_hostfile(self):
         """test clush --hostfile"""
@@ -629,10 +629,10 @@ class CLIClushTest_A(unittest.TestCase):
         """test clush --outdir and --errdir"""
         odir = make_temp_dir()
         edir = make_temp_dir()
-        tofilepath = os.path.join(odir, HOSTNAME)
-        tefilepath = os.path.join(edir, HOSTNAME)
+        tofilepath = os.path.join(odir.name, HOSTNAME)
+        tefilepath = os.path.join(edir.name, HOSTNAME)
         try:
-            self._clush_t(["-w", HOSTNAME, "--outdir", odir, "echo", "ok"],
+            self._clush_t(["-w", HOSTNAME, "--outdir", odir.name, "echo", "ok"],
                           None, self.output_ok)
             self.assertTrue(os.path.isfile(tofilepath))
             with open(tofilepath, "r") as f:
@@ -640,7 +640,7 @@ class CLIClushTest_A(unittest.TestCase):
         finally:
             os.unlink(tofilepath)
         try:
-            self._clush_t(["-w", HOSTNAME, "--errdir", edir, "echo", "ok", ">&2"],
+            self._clush_t(["-w", HOSTNAME, "--errdir", edir.name, "echo", "ok", ">&2"],
                           None, None, 0, self.output_ok)
             self.assertTrue(os.path.isfile(tefilepath))
             with open(tefilepath, "r") as f:
@@ -649,7 +649,7 @@ class CLIClushTest_A(unittest.TestCase):
             os.unlink(tefilepath)
         try:
             serr = "%s: err\n" % HOSTNAME
-            self._clush_t(["-w", HOSTNAME, "--outdir", odir, "--errdir", edir,
+            self._clush_t(["-w", HOSTNAME, "--outdir", odir.name, "--errdir", edir.name,
                           "echo", "ok", ";", "echo", "err", ">&2"], None,
                           self.output_ok, 0, serr.encode())
             self.assertTrue(os.path.isfile(tofilepath))
@@ -661,8 +661,8 @@ class CLIClushTest_A(unittest.TestCase):
         finally:
             os.unlink(tofilepath)
             os.unlink(tefilepath)
-        os.rmdir(odir)
-        os.rmdir(edir)
+        odir.cleanup()
+        edir.cleanup()
 
     def test_042_command_prefix(self):
         """test clush -O command_prefix"""

--- a/tests/CLIConfigTest.py
+++ b/tests/CLIConfigTest.py
@@ -327,12 +327,12 @@ class CLIClushConfigTest(unittest.TestCase):
         custom_config_save = os.environ.get('CLUSTERSHELL_CFGDIR')
 
         # Create fake CLUSTERSHELL_CFGDIR
-        custom_cfg_dir = make_temp_dir()
+        custom_cfg_dir = make_temp_dir(ignore_cleanup_errors=True)
 
         try:
-            os.environ['CLUSTERSHELL_CFGDIR'] = custom_cfg_dir
+            os.environ['CLUSTERSHELL_CFGDIR'] = custom_cfg_dir.name
 
-            cfgfile = open(os.path.join(custom_cfg_dir, 'clush.conf'), 'w')
+            cfgfile = open(os.path.join(custom_cfg_dir.name, 'clush.conf'), 'w')
             cfgfile.write(dedent("""
                 [Main]
                 fanout: 42
@@ -368,7 +368,7 @@ class CLIClushConfigTest(unittest.TestCase):
                 os.environ['CLUSTERSHELL_CFGDIR'] = custom_config_save
             else:
                 del os.environ['CLUSTERSHELL_CFGDIR']
-            shutil.rmtree(custom_cfg_dir, ignore_errors=True)
+            custom_cfg_dir.cleanup()
 
 
     def testClushConfigUserOverride(self):
@@ -377,12 +377,12 @@ class CLIClushConfigTest(unittest.TestCase):
         xdg_config_home_save = os.environ.get('XDG_CONFIG_HOME')
 
         # Create fake XDG_CONFIG_HOME
-        dname = make_temp_dir()
+        tdir = make_temp_dir(ignore_cleanup_errors=True)
         try:
-            os.environ['XDG_CONFIG_HOME'] = dname
+            os.environ['XDG_CONFIG_HOME'] = tdir.name
 
             # create $XDG_CONFIG_HOME/clustershell/clush.conf
-            usercfgdir = os.path.join(dname, 'clustershell')
+            usercfgdir = os.path.join(tdir.name, 'clustershell')
             os.mkdir(usercfgdir)
             cfgfile = open(os.path.join(usercfgdir, 'clush.conf'), 'w')
             cfgfile.write(dedent("""
@@ -420,12 +420,14 @@ class CLIClushConfigTest(unittest.TestCase):
                 os.environ['XDG_CONFIG_HOME'] = xdg_config_home_save
             else:
                 del os.environ['XDG_CONFIG_HOME']
-            shutil.rmtree(dname, ignore_errors=True)
+            tdir.cleanup()
 
     def testClushConfigConfDirModesEmpty(self):
         """test CLI.Config.ClushConfig (confdir with no modes)"""
-        dname1 = make_temp_dir()
-        dname2 = make_temp_dir()
+        tdir1 = make_temp_dir()
+        dname1 = tdir1.name
+        tdir2 = make_temp_dir()
+        dname2 = tdir2.name
         f = make_temp_file(dedent("""
             [Main]
             fanout: 42
@@ -465,14 +467,16 @@ class CLIClushConfigTest(unittest.TestCase):
             self.assertRaises(ClushConfigError, config.set_mode, "sshpass")
         finally:
             f.close()
-            os.rmdir(dname2)
-            os.rmdir(dname1)
+            tdir2.cleanup()
+            tdir1.cleanup()
 
 
     def testClushConfigConfDirModes(self):
         """test CLI.Config.ClushConfig (confdir and modes)"""
-        dname1 = make_temp_dir()
-        dname2 = make_temp_dir()
+        tdir1 = make_temp_dir()
+        dname1 = tdir1.name
+        tdir2 = make_temp_dir()
+        dname2 = tdir2.name
         # Notes:
         #   - use dname1 two times to check dup checking code
         #   - use quotes on one of the directory path
@@ -594,5 +598,5 @@ class CLIClushConfigTest(unittest.TestCase):
             f2.close()
             f1.close()
             f.close()
-            os.rmdir(dname2)
-            os.rmdir(dname1)
+            tdir2.cleanup()
+            tdir1.cleanup()

--- a/tests/CLINodesetTest.py
+++ b/tests/CLINodesetTest.py
@@ -797,25 +797,25 @@ class CLINodesetGroupResolverConfigErrorTest(CLINodesetTestBase):
     """Unit test class for testing GroupResolverConfigError"""
 
     def setUp(self):
-        self.dname = make_temp_dir()
+        self.tdir = make_temp_dir()
         self.gconff = make_temp_file(dedent("""
             [Main]
             default: default
             autodir: %s
-            """ % self.dname).encode('ascii'))
+            """ % self.tdir.name).encode('ascii'))
         self.yamlf = make_temp_file(dedent("""
             default:
                 compute: 'foo'
             broken: i am not a dict
-            """).encode('ascii'), suffix=".yaml", dir=self.dname)
+            """).encode('ascii'), suffix=".yaml", dir=self.tdir.name)
 
         set_std_group_resolver(GroupResolverConfig(self.gconff.name))
 
     def tearDown(self):
         set_std_group_resolver(None)
-        self.gconff = None
-        self.yamlf = None
-        os.rmdir(self.dname)
+        self.yamlf.close()
+        self.gconff.close()
+        self.tdir.cleanup()
 
     def test_bad_yaml_config(self):
         """test nodeset with bad yaml config"""

--- a/tests/DefaultsTest.py
+++ b/tests/DefaultsTest.py
@@ -102,20 +102,20 @@ class Defaults000NoConfigTest(unittest.TestCase):
         self.assertTrue(task.default("distant_worker") is WorkerSsh)
         task_terminate()
 
-        dname = make_temp_dir()
-        modfile = open(os.path.join(dname, 'OutOfTree.py'), 'w')
+        tdir = make_temp_dir(ignore_cleanup_errors=True)
+        modfile = open(os.path.join(tdir.name, 'OutOfTree.py'), 'w')
         modfile.write(dedent("""
             class OutOfTreeWorker(object):
                 pass
             WORKER_CLASS = OutOfTreeWorker"""))
         modfile.flush()
         modfile.close()
-        sys.path.append(dname)
+        sys.path.append(tdir.name)
         self.defaults.distant_workername = 'OutOfTree'
         task = task_self(self.defaults)
         self.assertEqual(task.default("distant_worker").__name__, 'OutOfTreeWorker')
         task_terminate()
-        shutil.rmtree(dname, ignore_errors=True)
+        tdir.cleanup()
 
     def test_005_misc_value_errors(self):
         """test Defaults misc value errors"""

--- a/tests/NodeSetTest.py
+++ b/tests/NodeSetTest.py
@@ -2030,11 +2030,6 @@ class NodeSetTest(unittest.TestCase):
         result = list(iter(ns1))
         self.assertEqual(result, ['da2c0', 'da2c1', 'da3c0', 'da3c1'])
 
-    def test_nd_iter(self):
-        ns1 = NodeSet("da[2-3]c[0-1]")
-        result = list(iter(ns1))
-        self.assertEqual(result, ['da2c0', 'da2c1', 'da3c0', 'da3c1'])
-
     def test_nd_nsiter(self):
         ns1 = NodeSet("da[2-3]c[0-1]")
         result = list(ns1.nsiter())

--- a/tests/TLib.py
+++ b/tests/TLib.py
@@ -5,8 +5,10 @@ Unit test library
 import os
 import socket
 import sys
-import tempfile
 import time
+
+from tempfile import mkstemp
+from tempfile import TemporaryFile, NamedTemporaryFile, TemporaryDirectory
 
 try:
     import configparser
@@ -55,24 +57,30 @@ def make_temp_filename(suffix=''):
     """Return a temporary name for a file."""
     if len(suffix) > 0 and suffix[0] != '-':
         suffix = '-' + suffix
-    fd, name = tempfile.mkstemp(suffix, prefix='cs-test-')
+    fd, name = mkstemp(suffix, prefix='cs-test-')
     os.close(fd)  # don't leak open fd
     return name
 
 def make_temp_file(text, suffix='', dir=None):
     """Create a temporary file with the provided text."""
     assert type(text) is bytes
-    tmp = tempfile.NamedTemporaryFile(prefix='cs-test-',
-                                      suffix=suffix, dir=dir)
+    tmp = NamedTemporaryFile(prefix='cs-test-',
+                             suffix=suffix, dir=dir)
     tmp.write(text)
     tmp.flush()
     return tmp
 
-def make_temp_dir(suffix=''):
+def make_temp_dir(suffix='', ignore_cleanup_errors=False):
     """Create a temporary directory."""
     if len(suffix) > 0 and suffix[0] != '-':
         suffix = '-' + suffix
-    return tempfile.mkdtemp(suffix, prefix='cs-test-')
+    try:
+        # ignore_cleanup_errors py3.10+
+        return TemporaryDirectory(suffix, prefix='cs-test-',
+                                  ignore_cleanup_errors=ignore_cleanup_errors)
+    except TypeError:
+        return TemporaryDirectory(suffix, prefix='cs-test-')
+
 
 #
 # CLI tests
@@ -93,7 +101,7 @@ def CLI_main(test, main, args, stdin, expected_stdout, expected_rc=0,
     if stdin is not None:
         if type(stdin) is bytes:
             # Use temporary file in Python 2 or with buffer (bytes) in Python 3
-            sys.stdin = tempfile.TemporaryFile()
+            sys.stdin = TemporaryFile()
             sys.stdin.write(stdin)
             sys.stdin.seek(0)  # ready to be read
         else:

--- a/tests/TaskDistantMixin.py
+++ b/tests/TaskDistantMixin.py
@@ -4,7 +4,6 @@
 """Unit test for ClusterShell Task (distant)"""
 
 import pwd
-import shutil
 import unittest
 import warnings
 
@@ -97,19 +96,21 @@ class TaskDistantMixin(object):
             self._task.set_default("stderr", False)
 
     def testLocalhostCopyDir(self):
-        dtmp_src = make_temp_dir('src')
-        dtmp_dst = make_temp_dir('testLocalhostCopyDir')
+        dtmp_src = make_temp_dir('src', ignore_cleanup_errors=True)
+        dtmp_dst = make_temp_dir('testLocalhostCopyDir',
+                                 ignore_cleanup_errors=True)
         try:
-            os.mkdir(os.path.join(dtmp_src, "lev1_a"))
-            os.mkdir(os.path.join(dtmp_src, "lev1_b"))
-            os.mkdir(os.path.join(dtmp_src, "lev1_a", "lev2"))
-            worker = self._task.copy(dtmp_src, dtmp_dst, nodes=HOSTNAME)
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_a"))
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_b"))
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_a", "lev2"))
+            worker = self._task.copy(dtmp_src.name, dtmp_dst.name,
+                                     nodes=HOSTNAME)
             self._task.resume()
-            self.assertTrue(os.path.exists(os.path.join(dtmp_dst,
-                            os.path.basename(dtmp_src), "lev1_a", "lev2")))
+            self.assertTrue(os.path.exists(os.path.join(dtmp_dst.name,
+                            os.path.basename(dtmp_src.name), "lev1_a", "lev2")))
         finally:
-            shutil.rmtree(dtmp_dst, ignore_errors=True)
-            shutil.rmtree(dtmp_src, ignore_errors=True)
+            dtmp_dst.cleanup()
+            dtmp_src.cleanup()
 
     def testLocalhostExplicitSshCopy(self):
         dest = make_temp_filename('testLocalhostExplicitSshCopy')
@@ -128,53 +129,56 @@ class TaskDistantMixin(object):
         self._task.set_info("scp_path", "/usr/bin/scp -l 10")
         self._task.set_info("scp_options", "-oLogLevel=QUIET")
         try:
-            worker = WorkerSsh(HOSTNAME, source="/etc/hosts", dest=dest,
+            worker = WorkerSsh(HOSTNAME, source="/etc/hosts", dest=dest.name,
                                handler=None)
             self._task.schedule(worker)
             self._task.resume()
             self.assertEqual(self._task.max_retcode(), 0)
-            self.assertTrue(os.path.exists(os.path.join(dest, "hosts")))
+            self.assertTrue(os.path.exists(os.path.join(dest.name, "hosts")))
         finally:
-            os.unlink(os.path.join(dest, "hosts"))
-            os.rmdir(dest)
+            os.unlink(os.path.join(dest.name, "hosts"))
+            dest.cleanup()
         # clear options after test
         task_cleanup()
         self.assertEqual(task_self().info("scp_path"), None)
 
     def testLocalhostExplicitSshCopyDir(self):
-        dtmp_src = make_temp_dir('src')
-        dtmp_dst = make_temp_dir('testLocalhostExplicitSshCopyDir')
+        dtmp_src = make_temp_dir('src', ignore_cleanup_errors=True)
+        dtmp_dst = make_temp_dir('testLocalhostExplicitSshCopyDir',
+                                 ignore_cleanup_errors=True)
         try:
-            os.mkdir(os.path.join(dtmp_src, "lev1_a"))
-            os.mkdir(os.path.join(dtmp_src, "lev1_b"))
-            os.mkdir(os.path.join(dtmp_src, "lev1_a", "lev2"))
-            worker = WorkerSsh(HOSTNAME, source=dtmp_src, dest=dtmp_dst,
-                               handler=None)
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_a"))
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_b"))
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_a", "lev2"))
+            worker = WorkerSsh(HOSTNAME, source=dtmp_src.name,
+                               dest=dtmp_dst.name, handler=None)
             self._task.schedule(worker)
             self._task.resume()
-            path = os.path.join(dtmp_dst, os.path.basename(dtmp_src), "lev1_a",
-                                "lev2")
+            path = os.path.join(dtmp_dst.name, os.path.basename(dtmp_src.name),
+                                "lev1_a", "lev2")
             self.assertTrue(os.path.exists(path))
         finally:
-            shutil.rmtree(dtmp_dst, ignore_errors=True)
-            shutil.rmtree(dtmp_src, ignore_errors=True)
+            dtmp_dst.cleanup()
+            dtmp_src.cleanup()
 
     def testLocalhostExplicitSshCopyDirPreserve(self):
-        dtmp_src = make_temp_dir('src')
-        dtmp_dst = make_temp_dir('testLocalhostExplicitSshCopyDirPreserve')
+        dtmp_src = make_temp_dir('src', ignore_cleanup_errors=True)
+        dtmp_dst = make_temp_dir('testLocalhostExplicitSshCopyDirPreserve',
+                                 ignore_cleanup_errors=True)
         try:
-            os.mkdir(os.path.join(dtmp_src, "lev1_a"))
-            os.mkdir(os.path.join(dtmp_src, "lev1_b"))
-            os.mkdir(os.path.join(dtmp_src, "lev1_a", "lev2"))
-            worker = WorkerSsh(HOSTNAME, source=dtmp_src, dest=dtmp_dst,
-                               handler=None, timeout=10, preserve=True)
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_a"))
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_b"))
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_a", "lev2"))
+            worker = WorkerSsh(HOSTNAME, source=dtmp_src.name,
+                               dest=dtmp_dst.name, handler=None, timeout=10,
+                               preserve=True)
             self._task.schedule(worker)
             self._task.resume()
-            self.assertTrue(os.path.exists(os.path.join(dtmp_dst,
-                            os.path.basename(dtmp_src), "lev1_a", "lev2")))
+            self.assertTrue(os.path.exists(os.path.join(dtmp_dst.name,
+                            os.path.basename(dtmp_src.name), "lev1_a", "lev2")))
         finally:
-            shutil.rmtree(dtmp_dst, ignore_errors=True)
-            shutil.rmtree(dtmp_src, ignore_errors=True)
+            dtmp_dst.cleanup()
+            dtmp_src.cleanup()
 
     def testExplicitSshWorker(self):
         # init worker
@@ -632,63 +636,71 @@ class TaskDistantMixin(object):
 
     def testLocalhostRCopy(self):
         try:
-            dest = make_temp_dir('testLocalhostRCopy')
+            dest = make_temp_dir('testLocalhostRCopy',
+                                 ignore_cleanup_errors=True)
             # use fake node 'aaa' to test rank > 0
-            worker = self._task.rcopy("/etc/hosts", dest, "aaa,%s" % HOSTNAME,
+            worker = self._task.rcopy("/etc/hosts", dest.name, "aaa,%s" % HOSTNAME,
                                       handler=None, timeout=10)
             self._task.resume()
             self.assertEqual(worker.source, "/etc/hosts")
-            self.assertEqual(worker.dest, dest)
-            self.assertTrue(os.path.exists(os.path.join(dest, "hosts.%s" % HOSTNAME)))
+            self.assertEqual(worker.dest, dest.name)
+            self.assertTrue(os.path.exists(os.path.join(dest.name,
+                                                        "hosts.%s" % HOSTNAME)))
         finally:
-            shutil.rmtree(dest, ignore_errors=True)
+            dest.cleanup()
 
     def testLocalhostExplicitSshReverseCopy(self):
-        dest = make_temp_dir('testLocalhostExplicitSshRCopy')
+        dest = make_temp_dir('testLocalhostExplicitSshRCopy',
+                             ignore_cleanup_errors=True)
         try:
-            worker = WorkerSsh(HOSTNAME, source="/etc/hosts", dest=dest,
+            worker = WorkerSsh(HOSTNAME, source="/etc/hosts", dest=dest.name,
                                handler=None, timeout=10, reverse=True)
             self._task.schedule(worker)
             self._task.resume()
             self.assertEqual(worker.source, "/etc/hosts")
-            self.assertEqual(worker.dest, dest)
-            self.assertTrue(os.path.exists(os.path.join(dest, "hosts.%s" % HOSTNAME)))
+            self.assertEqual(worker.dest, dest.name)
+            self.assertTrue(os.path.exists(os.path.join(dest.name,
+                                                        "hosts.%s" % HOSTNAME)))
         finally:
-            shutil.rmtree(dest, ignore_errors=True)
+            dest.cleanup()
 
     def testLocalhostExplicitSshReverseCopyDir(self):
-        dtmp_src = make_temp_dir('src')
-        dtmp_dst = make_temp_dir('testLocalhostExplicitSshReverseCopyDir')
+        dtmp_src = make_temp_dir('src', ignore_cleanup_errors=True)
+        dtmp_dst = make_temp_dir('testLocalhostExplicitSshReverseCopyDir',
+                                 ignore_cleanup_errors=True)
         try:
-            os.mkdir(os.path.join(dtmp_src, "lev1_a"))
-            os.mkdir(os.path.join(dtmp_src, "lev1_b"))
-            os.mkdir(os.path.join(dtmp_src, "lev1_a", "lev2"))
-            worker = WorkerSsh(HOSTNAME, source=dtmp_src, dest=dtmp_dst,
-                               handler=None, timeout=30, reverse=True)
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_a"))
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_b"))
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_a", "lev2"))
+            worker = WorkerSsh(HOSTNAME, source=dtmp_src.name,
+                               dest=dtmp_dst.name, handler=None, timeout=30,
+                               reverse=True)
             self._task.schedule(worker)
             self._task.resume()
-            self.assertTrue(os.path.exists(os.path.join(dtmp_dst,
-                "%s.%s" % (os.path.basename(dtmp_src), HOSTNAME), "lev1_a", "lev2")))
+            self.assertTrue(os.path.exists(os.path.join(dtmp_dst.name, "%s.%s" % \
+                    (os.path.basename(dtmp_src.name), HOSTNAME), "lev1_a", "lev2")))
         finally:
-            shutil.rmtree(dtmp_dst, ignore_errors=True)
-            shutil.rmtree(dtmp_src, ignore_errors=True)
+            dtmp_dst.cleanup()
+            dtmp_src.cleanup()
 
     def testLocalhostExplicitSshReverseCopyDirPreserve(self):
-        dtmp_src = make_temp_dir('src')
-        dtmp_dst = make_temp_dir('testLocalhostExplicitSshReverseCopyDirPreserve')
+        dtmp_src = make_temp_dir('src', ignore_cleanup_errors=True)
+        dtmp_dst = make_temp_dir('testLocalhostExplicitSshReverseCpDirPreserve',
+                                 ignore_cleanup_errors=True)
         try:
-            os.mkdir(os.path.join(dtmp_src, "lev1_a"))
-            os.mkdir(os.path.join(dtmp_src, "lev1_b"))
-            os.mkdir(os.path.join(dtmp_src, "lev1_a", "lev2"))
-            worker = WorkerSsh(HOSTNAME, source=dtmp_src, dest=dtmp_dst,
-                               handler=None, timeout=30, reverse=True)
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_a"))
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_b"))
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_a", "lev2"))
+            worker = WorkerSsh(HOSTNAME, source=dtmp_src.name,
+                               dest=dtmp_dst.name, handler=None, timeout=30,
+                               reverse=True)
             self._task.schedule(worker)
             self._task.resume()
-            self.assertTrue(os.path.exists(os.path.join(dtmp_dst,
-                "%s.%s" % (os.path.basename(dtmp_src), HOSTNAME), "lev1_a", "lev2")))
+            self.assertTrue(os.path.exists(os.path.join(dtmp_dst.name, "%s.%s" % \
+                    (os.path.basename(dtmp_src.name), HOSTNAME), "lev1_a", "lev2")))
         finally:
-            shutil.rmtree(dtmp_dst, ignore_errors=True)
-            shutil.rmtree(dtmp_src, ignore_errors=True)
+            dtmp_dst.cleanup()
+            dtmp_src.cleanup()
 
     def testErroneousSshPath(self):
         try:

--- a/tests/TaskDistantPdshMixin.py
+++ b/tests/TaskDistantPdshMixin.py
@@ -3,8 +3,6 @@
 
 """Unit test for ClusterShell Task (distant, pdsh worker)"""
 
-import shutil
-
 from TLib import HOSTNAME, make_temp_filename, make_temp_dir
 from ClusterShell.Event import EventHandler
 from ClusterShell.Task import *
@@ -12,6 +10,7 @@ from ClusterShell.Worker.Worker import WorkerBadArgumentError
 from ClusterShell.Worker.Pdsh import WorkerPdsh
 from ClusterShell.Worker.EngineClient import *
 
+import shutil
 import socket
 import unittest
 
@@ -63,57 +62,59 @@ class TaskDistantPdshMixin(object):
         dest = make_temp_dir('testLocalhostExplicitPdshCopyWithOptions')
         self._task.set_info("pdcp_path", "pdcp -p")
         try:
-            worker = WorkerPdsh(HOSTNAME, source="/etc/hosts", dest=dest,
+            worker = WorkerPdsh(HOSTNAME, source="/etc/hosts", dest=dest.name,
                                 handler=None)
             self._task.schedule(worker)
             self._task.resume()
             self.assertEqual(self._task.max_retcode(), 0)
-            self.assertTrue(os.path.exists(os.path.join(dest, "hosts")))
+            self.assertTrue(os.path.exists(os.path.join(dest.name, "hosts")))
         finally:
-            os.unlink(os.path.join(dest, "hosts"))
-            os.rmdir(dest)
+            os.unlink(os.path.join(dest.name, "hosts"))
+            dest.cleanup()
         # clear options after test
         task_cleanup()
         self.assertEqual(task_self().info("pdcp_path"), None)
 
     def testLocalhostExplicitPdshCopyDir(self):
         # test simple localhost copy dir with explicit pdsh worker
-        dtmp_src = make_temp_dir('src')
+        dtmp_src = make_temp_dir('src', ignore_cleanup_errors=True)
         # pdcp worker doesn't create custom destination directory
         dtmp_dst = make_temp_dir('testLocalhostExplicitPdshCopyDir')
         try:
-            os.mkdir(os.path.join(dtmp_src, "lev1_a"))
-            os.mkdir(os.path.join(dtmp_src, "lev1_b"))
-            os.mkdir(os.path.join(dtmp_src, "lev1_a", "lev2"))
-            worker = WorkerPdsh(HOSTNAME, source=dtmp_src,
-                                dest=dtmp_dst, handler=None, timeout=10)
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_a"))
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_b"))
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_a", "lev2"))
+            worker = WorkerPdsh(HOSTNAME, source=dtmp_src.name,
+                                dest=dtmp_dst.name, handler=None, timeout=10)
             self._task.schedule(worker)
             self._task.resume()
-            self.assertTrue(os.path.exists(os.path.join(dtmp_dst, \
-                os.path.basename(dtmp_src), "lev1_a", "lev2")))
+            self.assertTrue(os.path.exists(os.path.join( \
+                    dtmp_dst.name, os.path.basename(dtmp_src.name), "lev1_a", "lev2")))
         finally:
-            shutil.rmtree(dtmp_dst, ignore_errors=True)
-            shutil.rmtree(dtmp_src, ignore_errors=True)
+            dtmp_dst.cleanup()
+            dtmp_src.cleanup()
 
     def testLocalhostExplicitPdshCopyDirPreserve(self):
         # test simple localhost preserve copy dir with explicit pdsh worker
-        dtmp_src = make_temp_dir('src')
+        dtmp_src = make_temp_dir('src', ignore_cleanup_errors=True)
         # pdcp worker doesn't create custom destination directory
-        dtmp_dst = make_temp_dir('testLocalhostExplicitPdshCopyDirPreserve')
+        dtmp_dst = make_temp_dir('testLocalhostExplicitPdshCopyDirPreserve',
+                                 ignore_cleanup_errors=True)
         try:
-            os.mkdir(os.path.join(dtmp_src, "lev1_a"))
-            os.mkdir(os.path.join(dtmp_src, "lev1_b"))
-            os.mkdir(os.path.join(dtmp_src, "lev1_a", "lev2"))
-            worker = WorkerPdsh(HOSTNAME, source=dtmp_src, dest=dtmp_dst,
-                                handler=None, timeout=10, preserve=True)
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_a"))
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_b"))
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_a", "lev2"))
+            worker = WorkerPdsh(HOSTNAME, source=dtmp_src.name,
+                                dest=dtmp_dst.name, handler=None, timeout=10,
+                                preserve=True)
             self._task.schedule(worker)
             self._task.resume()
-            self.assertTrue(os.path.exists(os.path.join(dtmp_dst,
-                                                        os.path.basename(dtmp_src),
-                                                        "lev1_a", "lev2")))
+            self.assertTrue(os.path.exists(os.path.join( \
+                    dtmp_dst.name, os.path.basename(dtmp_src.name),
+                    "lev1_a", "lev2")))
         finally:
-            shutil.rmtree(dtmp_dst, ignore_errors=True)
-            shutil.rmtree(dtmp_src, ignore_errors=True)
+            dtmp_dst.cleanup()
+            dtmp_src.cleanup()
 
     def testExplicitPdshWorker(self):
         # test simple localhost command with explicit pdsh worker
@@ -450,42 +451,47 @@ class TaskDistantPdshMixin(object):
 
     def testLocalhostExplicitPdshReverseCopyDir(self):
         # test simple localhost rcopy dir with explicit pdsh worker
-        dtmp_src = make_temp_dir('src')
-        dtmp_dst = make_temp_dir('testLocalhostExplicitPdshReverseCopyDir')
+        dtmp_src = make_temp_dir('src', ignore_cleanup_errors=True)
+        dtmp_dst = make_temp_dir('testLocalhostExplicitPdshReverseCopyDir',
+                                 ignore_cleanup_errors=True)
         try:
-            os.mkdir(os.path.join(dtmp_src, "lev1_a"))
-            os.mkdir(os.path.join(dtmp_src, "lev1_b"))
-            os.mkdir(os.path.join(dtmp_src, "lev1_a", "lev2"))
-            worker = WorkerPdsh(HOSTNAME, source=dtmp_src, dest=dtmp_dst,
-                                handler=None, timeout=30, reverse=True)
-            self._task.schedule(worker)
-            self._task.resume()
-            tgt = os.path.join(dtmp_dst, "%s.%s" % (os.path.basename(dtmp_src),
-                                                    HOSTNAME), "lev1_a", "lev2")
-            self.assertTrue(os.path.exists(tgt))
-        finally:
-            shutil.rmtree(dtmp_dst, ignore_errors=True)
-            shutil.rmtree(dtmp_src, ignore_errors=True)
-
-    def testLocalhostExplicitPdshReverseCopyDirPreserve(self):
-        # test simple localhost preserve rcopy dir with explicit pdsh worker
-        dtmp_src = make_temp_dir('src')
-        dtmp_dst = make_temp_dir('testLocalhostExplicitPdshReverseCopyDirPreserve')
-        try:
-            os.mkdir(os.path.join(dtmp_src, "lev1_a"))
-            os.mkdir(os.path.join(dtmp_src, "lev1_b"))
-            os.mkdir(os.path.join(dtmp_src, "lev1_a", "lev2"))
-            worker = WorkerPdsh(HOSTNAME, source=dtmp_src, dest=dtmp_dst,
-                                handler=None, timeout=30, preserve=True,
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_a"))
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_b"))
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_a", "lev2"))
+            worker = WorkerPdsh(HOSTNAME, source=dtmp_src.name,
+                                dest=dtmp_dst.name, handler=None, timeout=30,
                                 reverse=True)
             self._task.schedule(worker)
             self._task.resume()
-            tgt = os.path.join(dtmp_dst, "%s.%s" % (os.path.basename(dtmp_src),
-                                                    HOSTNAME), "lev1_a", "lev2")
+            tgt = os.path.join(dtmp_dst.name, "%s.%s" % \
+                    (os.path.basename(dtmp_src.name), HOSTNAME), "lev1_a",
+                    "lev2")
             self.assertTrue(os.path.exists(tgt))
         finally:
-            shutil.rmtree(dtmp_dst, ignore_errors=True)
-            shutil.rmtree(dtmp_src, ignore_errors=True)
+            dtmp_dst.cleanup()
+            dtmp_src.cleanup()
+
+    def testLocalhostExplicitPdshReverseCopyDirPreserve(self):
+        # test simple localhost preserve rcopy dir with explicit pdsh worker
+        dtmp_src = make_temp_dir('src', ignore_cleanup_errors=True)
+        dtmp_dst = make_temp_dir('testLocalhostExplicitPdshRevCpDirPreserve',
+                                 ignore_cleanup_errors=True)
+        try:
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_a"))
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_b"))
+            os.mkdir(os.path.join(dtmp_src.name, "lev1_a", "lev2"))
+            worker = WorkerPdsh(HOSTNAME, source=dtmp_src.name,
+                                dest=dtmp_dst.name, handler=None, timeout=30,
+                                preserve=True, reverse=True)
+            self._task.schedule(worker)
+            self._task.resume()
+            tgt = os.path.join(dtmp_dst.name, "%s.%s" % \
+                    (os.path.basename(dtmp_src.name), HOSTNAME), "lev1_a",
+                    "lev2")
+            self.assertTrue(os.path.exists(tgt))
+        finally:
+            dtmp_dst.cleanup()
+            dtmp_src.cleanup()
 
     class TEventHandlerEvCountChecker(EventHandler):
         """simple event count validator"""

--- a/tests/TaskLocalMixin.py
+++ b/tests/TaskLocalMixin.py
@@ -118,18 +118,6 @@ class TaskLocalMixin(object):
         except TimeoutError:
             self.fail("did detect timeout")
 
-    def testSimpleCommandNoTimeout(self):
-        task = task_self()
-
-        # init worker
-        worker = task.shell("/bin/usleep 900000")
-
-        try:
-            # run task
-            task.resume(1)
-        except TimeoutError:
-            self.fail("did detect timeout")
-
     def testWorkersTimeout(self):
         task = task_self()
 

--- a/tests/TreeWorkerTest.py
+++ b/tests/TreeWorkerTest.py
@@ -13,7 +13,6 @@ You can use the following options in ~/.ssh/config:
 
 import os
 from os.path import basename, join
-import shutil
 import unittest
 import warnings
 
@@ -337,13 +336,15 @@ class TreeWorkerTest(unittest.TestCase):
 
         srcdir = make_temp_dir()
         destdir = make_temp_dir()
-        file1 = make_temp_file(b'Lorem Ipsum Unum', suffix=".txt", dir=srcdir)
-        file2 = make_temp_file(b'Lorem Ipsum Duo', suffix=".txt", dir=srcdir)
+        file1 = make_temp_file(b'Lorem Ipsum Unum', suffix=".txt",
+                               dir=srcdir.name)
+        file2 = make_temp_file(b'Lorem Ipsum Duo', suffix=".txt",
+                               dir=srcdir.name)
 
         try:
             # add '/' to dest so that distant does like the others
-            worker = self.task.copy(srcdir, destdir + '/', nodes=target,
-                                    handler=teh)
+            worker = self.task.copy(srcdir.name, destdir.name + '/',
+                                    nodes=target, handler=teh)
             self.task.run()
             self.assertEqual(teh.ev_start_cnt, 1)
             self.assertEqual(teh.ev_pickup_cnt, 1)
@@ -354,18 +355,16 @@ class TreeWorkerTest(unittest.TestCase):
             self.assertEqual(teh.ev_close_cnt, 1)
 
             # copy successful?
-            copy_dest = join(destdir, srcdir)
+            copy_dest = join(destdir.name, srcdir.name)
             with open(join(copy_dest, basename(file1.name)), 'rb') as rfile1:
                 self.assertEqual(rfile1.read(), b'Lorem Ipsum Unum')
             with open(join(copy_dest, basename(file2.name)), 'rb') as rfile2:
                 self.assertEqual(rfile2.read(), b'Lorem Ipsum Duo')
         finally:
-            # src
-            file1 = None
-            file2 = None
-            os.rmdir(srcdir)
-            # dest
-            shutil.rmtree(destdir)
+            file1.close()
+            file2.close()
+            srcdir.cleanup()
+            destdir.cleanup()
 
     def test_tree_copy_dir_distant(self):
         """test tree copy: directory, distant target"""
@@ -388,11 +387,14 @@ class TreeWorkerTest(unittest.TestCase):
 
         srcdir = make_temp_dir()
         destdir = make_temp_dir()
-        file1 = make_temp_file(b'Lorem Ipsum Unum', suffix=".txt", dir=srcdir)
-        file2 = make_temp_file(b'Lorem Ipsum Duo', suffix=".txt", dir=srcdir)
+        file1 = make_temp_file(b'Lorem Ipsum Unum', suffix=".txt",
+                               dir=srcdir.name)
+        file2 = make_temp_file(b'Lorem Ipsum Duo', suffix=".txt",
+                               dir=srcdir.name)
 
         try:
-            worker = self.task.rcopy(srcdir, destdir, nodes=target, handler=teh)
+            worker = self.task.rcopy(srcdir.name, destdir.name, nodes=target,
+                                     handler=teh)
             self.task.run()
             self.assertEqual(teh.ev_start_cnt, 1)
             self.assertEqual(teh.ev_pickup_cnt, 1)
@@ -405,18 +407,17 @@ class TreeWorkerTest(unittest.TestCase):
             # rcopy successful?
             if not dirsuffix:
                 dirsuffix = target
-            rcopy_dest = join(destdir, basename(srcdir) + '.' + dirsuffix)
+            rcopy_dest = join(destdir.name,
+                              basename(srcdir.name) + '.' + dirsuffix)
             with open(join(rcopy_dest, basename(file1.name)), 'rb') as rfile1:
                 self.assertEqual(rfile1.read(), b'Lorem Ipsum Unum')
             with open(join(rcopy_dest, basename(file2.name)), 'rb') as rfile2:
                 self.assertEqual(rfile2.read(), b'Lorem Ipsum Duo')
         finally:
-            # src
-            file1 = None
-            file2 = None
-            os.rmdir(srcdir)
-            # dest
-            shutil.rmtree(destdir)
+            file1.close()
+            file2.close()
+            srcdir.cleanup()
+            destdir.cleanup()
 
     def test_tree_rcopy_dir_distant(self):
         """test tree rcopy: directory, distant target"""


### PR DESCRIPTION
- Python 2 testing is not supported – disabling
- Enable Python 3.10 - 3.11 testing via [nose-py3](https://pypi.org/project/nose-py3/)
- Misc improvements