### PR TITLE
Topology: check that node groups/wildcards are non-empty (#527)

### DIFF
--- a/doc/sphinx/tools/clush.rst
+++ b/doc/sphinx/tools/clush.rst
@@ -207,14 +207,16 @@ Configuration
 """""""""""""
 
 The system-wide library configuration file **/etc/clustershell/topology.conf**
-defines the routes of default command propagation tree. It is recommended that
-all connections between parent and children nodes are carefully
+defines available/preferred routes for the command propagation tree. It is
+recommended that all connections between parent and children nodes are carefully
 pre-configured, for example, to avoid any SSH warnings when connecting (if
 using the default SSH remote worker, of course).
 
 .. highlight:: ini
 
-The content of the topology.conf file should look like this::
+The file **topology.conf** is used to define a set of routes under a
+``[routes]`` section. Think of it as a routing table but for cluster
+commands. Node sets should be used when possible, for example::
 
   [routes]
   rio0: rio[10-13]
@@ -223,7 +225,7 @@ The content of the topology.conf file should look like this::
 
 .. highlight:: text
 
-This file defines the following topology graph::
+The example above defines the following topology graph::
 
     rio0
     |- rio[10-11]
@@ -231,6 +233,9 @@ This file defines the following topology graph::
     `- rio[12-13]
        `- rio[300-440]
 
+:ref:`nodeset-groups` and :ref:`node-wildcards` are supported in
+**topology.conf**, but any route definition with an empty node set
+is ignored (a message is printed in debug mode in that case).
 
 At runtime, ClusterShell will pick an initial propagation tree from this
 topology graph definition and the current root node. Multiple admin/root

--- a/doc/sphinx/tools/nodeset.rst
+++ b/doc/sphinx/tools/nodeset.rst
@@ -910,6 +910,8 @@ like::
 A similar option is available with :ref:`clush-tool`, see
 :ref:`selecting all nodes with clush <clush-all-nodes>`.
 
+.. _node-wildcards:
+
 Node wildcards
 """"""""""""""
 


### PR DESCRIPTION
Router and destination node sets defined in topology.conf may use NodeSet groups and wildcards but those have to resolve to non-empty node sets when we build the tree.

Add checks for this in the code and add a note to the documentation.

Fixes #527.