### PR TITLE
CLI: fix line buffering with Python 3 (#528)

### DIFF
--- a/tests/CLIClubakTest.py
+++ b/tests/CLIClubakTest.py
@@ -65,6 +65,11 @@ class CLIClubakTest(unittest.TestCase):
         self._clubak_t(["-v", "-b"], b"foo: bar\n", _outfmt_verb('foo'), 0)
         # no node count with -q
         self._clubak_t(["-q", "-b"], b"foo[1-5]: bar\n", _outfmt('foo[1-5]'), 0)
+        # non-printable characters replaced by the replacement character
+        self._clubak_t(["-L"], b"foo:\xffbar\n", "foo: \ufffdbar\n".encode(), 0)
+        self._clubak_t(["-d", "-L"], b"foo:\xf8bar\n",
+                       'INPUT foo:\ufffdbar\nfoo: \ufffdbar\n'.encode(), 0,
+                       b'line_mode=True gather=False tree_depth=1\n')
 
     def test_002_b(self):
         """test clubak (gather -b)"""
@@ -118,6 +123,8 @@ class CLIClubakTest(unittest.TestCase):
         """test clubak (tree mode --tree)"""
         self._clubak_t(["--tree"], b"foo: bar\n", _outfmt("foo"))
         self._clubak_t(["--tree", "-L"], b"foo: bar\n", b"foo:\n bar\n")
+        self._clubak_t(["--tree", "-L"], b"foo: \xf8bar\n",
+                       "foo:\n \ufffdbar\n".encode())
         stdin_buf = dedent("""foo1:bar
                               foo2:bar
                               foo1:moo

--- a/tests/TLib.py
+++ b/tests/TLib.py
@@ -29,14 +29,11 @@ class TBytesIO(BytesIO):
 
     def __init__(self, initial_bytes=None):
         if initial_bytes and type(initial_bytes) is not bytes:
-            initial_bytes = initial_bytes.encode('ascii')
+            initial_bytes = initial_bytes.encode()
         BytesIO.__init__(self, initial_bytes)
 
-    def write(self, b):
-        if type(b) is bytes:
-            BytesIO.write(self, b)
-        else:
-            BytesIO.write(self, b.encode('ascii'))
+    def write(self, s):
+        BytesIO.write(self, s.encode())
 
     def isatty(self):
         return False
@@ -104,8 +101,9 @@ def CLI_main(test, main, args, stdin, expected_stdout, expected_rc=0,
             # should be read in text mode for some tests (eg. Nodeset).
             sys.stdin = StringIO(stdin)
 
-    # Output: ClusterShell sends bytes to sys_stdout()/sys_stderr() and when
-    # print() is used, TBytesIO does a conversion to ascii.
+    # Output: ClusterShell writes to stdout/stderr using strings, but the tests
+    # expect bytes. TBytesIO is a wrapper that does the conversion until we
+    # migrate all tests to string.
     sys.stdout = out = TBytesIO()
     sys.stderr = err = TBytesIO()
     sys.argv = args


### PR DESCRIPTION
When the code was ported to Python 3, we switched to sys.stdout.buffer and sys.stderr.buffer that use BufferedWriter (bytes) for printing outputs. However, this method doesn't work great for line buffering, which is used a lot by clush and clubak.

Switch back to sys.stdout and sys.stderr, as TextIOWrapper objects, which take strings and benefit from automatic line buffering. If stdout (or stderr) is not a tty, we reconfigure it (only once) to force line buffering. Indeed, clush and clubak might be piped to other tools (like pv) that expects each line to be flushed.

Key points of this patch:

- write() to stdout/stderr now takes a string and the Display class is in charge of performing the needed bytes-to-string decoding

- any non-printable character will be decoded to U+FFFD thanks to `errors='replace'`; U+FFFD is the official REPLACEMENT CHARACTER (this is now tested in CLIDisplayTest.py)

- when the Display object is initialized, we make sure stdout/stderr are configured with line buffering enabled

- the print methods from Display like print_line(), print_line_error() and _print_content() still take bytes as argument. Buffers are still mainly handled as bytes internally (by MsgTreeElem).

- most CLI tests remain unchanged for now: they capture the output (now as string) and compare against expected bytes, but proper encoding is done by TLib in CLI_main(). In the future, we could convert all tests from using bytes to string to make it easier.

Fixes #528.