### PR TITLE
NodeUtils: allow null values in cluster.yaml (#533)

### DIFF
--- a/doc/sphinx/config.rst
+++ b/doc/sphinx/config.rst
@@ -344,6 +344,10 @@ Here is an example of **/etc/clustershell/groups.d/cluster.yaml**::
         oss: 'oss[0-15]'
         rbh: 'rbh[1-2]'
 
+
+If you wish to define an empty group (with no nodes), you can either use an
+empty string ``''`` or any valid YAML null value (``null`` or ``~``).
+
 .. highlight:: console
 
 Testing the syntax of your group file can be quickly performed through the

--- a/lib/ClusterShell/NodeUtils.py
+++ b/lib/ClusterShell/NodeUtils.py
@@ -329,11 +329,14 @@ class YAMLGroupLoader(object):
                 fmt = "%s: invalid content (group source '%s' is not a dict)"
                 raise GroupResolverConfigError(fmt % (self.filename, srcname))
 
-            for grp in groups:
+            for grp, grpnodes in groups.items():
                 if not isinstance(grp, basestring):
                     fmt = '%s: %s: group name %s not a string (add quotes?)'
                     raise GroupResolverConfigError(fmt % (self.filename,
                                                           srcname, grp))
+                # GH#533: interpret null value as empty set
+                if grpnodes is None:
+                    groups[grp] = ''
 
             if first:
                 self._groups[srcname] = groups

--- a/tests/NodeSetGroupTest.py
+++ b/tests/NodeSetGroupTest.py
@@ -1814,7 +1814,6 @@ class GroupResolverYAMLTest(unittest.TestCase):
             yamlfile.close()
             tdir.cleanup()
 
-
     def test_wrong_autodir(self):
         """test wrong autodir (doesn't exist)"""
         f = make_temp_file(dedent("""
@@ -1880,3 +1879,29 @@ class GroupResolverYAMLTest(unittest.TestCase):
             yamlfile1.close()
             yamlfile2.close()
             tdir.cleanup()
+
+    def test_yaml_null_value(self):
+        """test null value in groups yaml file"""
+        tdir = make_temp_dir()
+        f = make_temp_file(dedent("""
+            [Main]
+            default: yaml
+            autodir: %s
+            """ % tdir.name).encode('ascii'))
+        yamlfile = make_temp_file(dedent("""
+            yaml:
+                c0: nid[0001-0032]
+                c1:
+                c0r7: nid[0017-0032]
+            """).encode('ascii'), suffix=".yaml", dir=tdir.name)
+        try:
+            res = GroupResolverConfig(f.name)
+            nodeset = NodeSet.fromall(resolver=res)
+            self.assertEqual(str(nodeset), "nid[0001-0032]")
+            nodeset = NodeSet("@c1", resolver=res)
+            self.assertEqual(len(nodeset), 0)
+            self.assertEqual(str(nodeset), "")
+        finally:
+            yamlfile.close()
+            tdir.cleanup()
+


### PR DESCRIPTION
An empty group can already be defined by specifying an empty string as value in the yaml file.

For convenience, now also interpret any YAML null value as an empty set.

Fixes #533.