### PR TITLE
Update clush.rst to fix broken URL for llnl.gov pdsh page

### DIFF
--- a/doc/sphinx/tools/clush.rst
+++ b/doc/sphinx/tools/clush.rst
@@ -773,7 +773,7 @@ specifying the case-sensitive full Python module name of a worker module.
 
 
 .. [#] LLNL parallel remote shell utility
-   (https://computing.llnl.gov/linux/pdsh.html)
+   (https://software.llnl.gov/repo/#!/chaos/pdsh)
 
 .. _seq(1): http://linux.die.net/man/1/seq
 .. _Python unified diff:


### PR DESCRIPTION
LLNL pdsh URL broken; Updating link to LLNL software catalog pdsh page.