### PR TITLE
Drop support for insecure end-of-life Python <=3.7

### DIFF
--- a/.github/workflows/nosetests.yml
+++ b/.github/workflows/nosetests.yml
@@ -8,10 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11']
-        include:
-          - os: ubuntu-20.04
-            python-version: '3.6'
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     name: Tests with Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Requirements
 
  * GNU/Linux, BSD, Mac OS X
  * OpenSSH (ssh/scp) or rsh
- * Python 2.x (x >= 7) or Python 3.x (x >= 6)
+ * Python >=3.8
  * PyYAML
 
 License

--- a/doc/sphinx/install.rst
+++ b/doc/sphinx/install.rst
@@ -27,15 +27,9 @@ For instance, ClusterShell is known to work on the following operating systems:
 
 * GNU/Linux
 
-  * Red Hat Enterprise Linux 7 (Python 2.7)
-
-  * Red Hat Enterprise Linux 8 (Python 3.6)
-
   * Red Hat Enterprise Linux 9 (Python 3.9)
 
   * Fedora 30 and above (Python 2.7 to 3.10+)
-
-  * Debian 10 "buster" (Python 3.7)
 
   * Debian 11 "bullseye" (Python 3.9)
 
@@ -68,21 +62,9 @@ ClusterShell packages as found in some common Linux distributions:
 | Operating        | System Python version used | Alternate Python support          |
 | System           | by the clustershell tools  | packaged (version-suffixed tools) |
 +==================+============================+===================================+
-| RHEL 7           | Python 2.7                 | Python 3.6                        |
-+------------------+----------------------------+-----------------------------------+
-| RHEL 8           | **Python 3.6**             |                                   |
-+------------------+----------------------------+-----------------------------------+
 | RHEL 9           | **Python 3.9**             |                                   |
 +------------------+----------------------------+-----------------------------------+
 | Fedora 36        | **Python 3.10**            |                                   |
-+------------------+----------------------------+-----------------------------------+
-| openSUSE Leap 15 | Python 2.7                 | Python 3.6                        |
-+------------------+----------------------------+-----------------------------------+
-| SUSE SLES 12     | Python 2.7                 | Python 3.4                        |
-+------------------+----------------------------+-----------------------------------+
-| SUSE SLES 15     | Python 2.7                 | Python 3.6                        |
-+------------------+----------------------------+-----------------------------------+
-| Ubuntu 18.04 LTS | **Python 3.6**             |                                   |
 +------------------+----------------------------+-----------------------------------+
 | Ubuntu 20.04 LTS | **Python 3.8**             |                                   |
 +------------------+----------------------------+-----------------------------------+

--- a/lib/ClusterShell/CLI/Display.py
+++ b/lib/ClusterShell/CLI/Display.py
@@ -118,17 +118,11 @@ class Display(object):
         self._color = color
         # GH#528 enable line buffering
         self.out = sys.stdout
-        try :
-            if not self.out.line_buffering:
-                self.out.reconfigure(line_buffering=True)
-        except AttributeError:  # < py3.7
-            pass
+        if not self.out.line_buffering:
+            self.out.reconfigure(line_buffering=True)
         self.err = sys.stderr
-        try :
-            if not self.err.line_buffering:
-                self.err.reconfigure(line_buffering=True)
-        except AttributeError:  # < py3.7
-            pass
+        if not self.err.line_buffering:
+            self.err.reconfigure(line_buffering=True)
 
         if self._color:
             self.color_stdout_fmt = self.COLOR_STDOUT_FMT

--- a/setup.py
+++ b/setup.py
@@ -85,11 +85,12 @@ setup(name='ClusterShell',
           "Operating System :: POSIX :: BSD",
           "Operating System :: POSIX :: Linux",
           "Programming Language :: Python",
-          "Programming Language :: Python :: 2.7",
           "Programming Language :: Python :: 3",
+          "Programming Language :: Python :: 3 :: Only",
           "Topic :: Software Development :: Libraries :: Python Modules",
           "Topic :: System :: Clustering",
           "Topic :: System :: Distributed Computing"
       ],
+      python_requires='>=3.8',
       install_requires=REQUIRES,
      )


### PR DESCRIPTION
Hi!

I'm not sure how welcome this is, I just became aware that clustershell tries supporting some insecure end-of-life versions of Python, so I decided to offer this pull request to get rid of that baggage, and see what you think :beers: 

Best, Sebastian