### PR TITLE
Fix tests for libexpat >=2.6.0 (or with CVE-2023-52425 fixes backported)

### DIFF
--- a/tests/TreeGatewayTest.py
+++ b/tests/TreeGatewayTest.py
@@ -135,6 +135,8 @@ class TreeGatewayBaseTest(unittest.TestCase):
                 break
             self.assertTrue(type(xml_msg) is bytes)
             self.parser.feed(xml_msg)
+            if hasattr(self.parser, 'flush'):  # >=3.13 and backports
+                self.parser.flush()
 
         return self.xml_reader.pop_msg()
 

--- a/tests/TreeGatewayTest.py
+++ b/tests/TreeGatewayTest.py
@@ -131,7 +131,8 @@ class TreeGatewayBaseTest(unittest.TestCase):
         while not self.xml_reader.msg_available():
             xml_msg = self.gateway.recv()
             if len(xml_msg) == 0:
-                return None
+                self.parser.close()
+                break
             self.assertTrue(type(xml_msg) is bytes)
             self.parser.feed(xml_msg)
 


### PR DESCRIPTION
Hi! :wave: 

It was reported that the clustershell test suite breaks with Expat >=2.6.0 (https://bugs.gentoo.org/924601). So this pull request fixes the test suite for Expat >=2.6.0 with CPython 3.13 and backport releases by using the new pyexpat API (https://github.com/python/cpython/issues/115398). There is no rush in merging this, we can definitey wait for that APi to become more widely available if you like, it will likely appear in these very CPython releases:

- 3.8.19
- 3.9.19
- 3.10.14
- 3.11.9
- 3.12.3
- 3.13.0

I should note that Python 3.7 and earlier are dead, hence related pull request #555.
I'm looking forward to your review, maybe I missed something :beers: 

Best, Sebastian