### PR TITLE
Additional Slurm example bindings

### DIFF
--- a/conf/groups.conf.d/slurm.conf.example
+++ b/conf/groups.conf.d/slurm.conf.example
@@ -39,3 +39,21 @@ map: squeue -h -u $GROUP -o "%N" -t R
 list: squeue -h -o "%u" -t R
 reverse: squeue -h -w $NODE -o "%u"
 cache_time: 60
+
+#
+# SLURM account bindings for running jobs
+#
+[slurmaccount,sa]
+map: squeue -h -A $GROUP -o "%N" -t R
+list: squeue -h -o "%a" -t R
+reverse: squeue -h -w $NODE -o "%a" 2>/dev/null || true
+cache_time: 60
+
+#
+# SLURM QOS bindings for running jobs
+#
+[slurmqos,sq]
+map: squeue -h -q $GROUP -o "%N" -t R
+list: squeue -h -o "%q" -t R
+reverse: squeue -h -w $NODE -o "%q" 2>/dev/null || true
+cache_time: 60


### PR DESCRIPTION
Provide more Slurm example bindings, to interact with nodes running jobs from specific accounts, or under specific QOSes.

#### Examples

Generate a folded nodeset from all the nodes running jobs from the `myacc` Slurm account:
```
$ cluset -f @slurmaccount:myacc
```

Count the number nodes running jobs submitted with the `long` QOS:
```
$ cluset -f @slurmqos:long
```