### PR TITLE
Additional Slurm binding for mapping nodes to reservations

### DIFF
--- a/conf/groups.conf.d/slurm.conf.example
+++ b/conf/groups.conf.d/slurm.conf.example
@@ -19,7 +19,6 @@ reverse: sinfo -h -N -o "%R" -n $NODE
 map: scontrol -o show reservation $GROUP | grep -Po 'Nodes=\K[^ ]+'
 all: scontrol -o show reservation | grep -Po 'Nodes=\K[^ ]+'
 list: scontrol -o show reservation | grep -Po 'ReservationName=\K[^ ]+'
-reverse: scontrol -o show node $NODE | grep -Po 'ReservationName=\K[^ ]+' 2>/dev/null || true
 cache_time: 60
 
 #

--- a/conf/groups.conf.d/slurm.conf.example
+++ b/conf/groups.conf.d/slurm.conf.example
@@ -16,8 +16,8 @@ reverse: sinfo -h -N -o "%R" -n $NODE
 # SLURM node-reservation bindings
 #
 [slurmresv,sr]
-map: scontrol -o show reservation $GROUP | grep -Po 'Nodes=\K[^ ]+' | xargs | tr ' ' ','
-all: scontrol -o show reservation | grep -Po 'Nodes=\K[^ ]+' | tr '\n' ','
+map: scontrol -o show reservation $GROUP | grep -Po 'Nodes=\K[^ ]+'
+all: scontrol -o show reservation | grep -Po 'Nodes=\K[^ ]+'
 list: scontrol -o show reservation | grep -Po 'ReservationName=\K[^ ]+'
 reverse: scontrol -o show node $NODE | grep -Po 'ReservationName=\K[^ ]+' 2>/dev/null || true
 cache_time: 60

--- a/conf/groups.conf.d/slurm.conf.example
+++ b/conf/groups.conf.d/slurm.conf.example
@@ -13,6 +13,16 @@ list: sinfo -h -o "%R"
 reverse: sinfo -h -N -o "%R" -n $NODE
 
 #
+# SLURM node-reservation bindings
+#
+[slurmresv,sr]
+map: scontrol -o show reservation $GROUP | grep -Po 'Nodes=\K[^ ]+' | xargs | tr ' ' ','
+all: scontrol -o show reservation | grep -Po 'Nodes=\K[^ ]+' | tr '\n' ','
+list: scontrol -o show reservation | grep -Po 'ReservationName=\K[^ ]+'
+reverse: scontrol -o show node $NODE | grep -Po 'ReservationName=\K[^ ]+' 2>/dev/null || true
+cache_time: 60
+
+#
 # SLURM state bindings
 #
 [slurmstate,st]


### PR DESCRIPTION
To list nodes in reservation `foobar`
```
$ cluset -f @sr:foobar
sh02-01n60
```

To list reservations that node `sh03-01n72` is part of:
```
$ cluset -ll -s slurmresv sh03-01n72
@slurmresv:test sh03-01n72
$ cluset -f @slurmresv:test
sh03-01n[71-72]
```