### PR TITLE
Tree: use set instead of NodeSet for gwtargets tracking

### DIFF
--- a/lib/ClusterShell/CLI/Clush.py
+++ b/lib/ClusterShell/CLI/Clush.py
@@ -416,10 +416,10 @@ class RunTimer(EventHandler):
         gwcnt = len(self.task.gateways)
         if gwcnt:
             # tree mode
-            act_targets = NodeSet()
+            act_targets = set()
             for gw, (chan, metaworkers) in self.task.gateways.items():
-                act_targets.updaten(mw.gwtargets[gw].copy()
-                                    for mw in metaworkers)
+                for mw in metaworkers:
+                    act_targets.update(mw.gwtargets[gw])
             cnt = len(act_targets) + len(self.task._engine.clients()) - gwcnt
             gwinfo = ' gw %d' % gwcnt
         else:
@@ -598,15 +598,14 @@ def ttyloop(task, nodeset, timeout, display, remote, trytree):
                                    % (len(ns_reg), ns_reg, pending,
                                       len(gws), NodeSet._fromlist1(gws)))
             for gw, (chan, metaworkers) in task.gateways.items():
-                act_targets = NodeSet()
+                act_targets = set()
                 for mw in metaworkers:
-                    # Compute active targets using updaten() from a copy of the
-                    # original sets as they might be frequently modified
-                    act_targets.updaten(mw.gwtargets[gw].copy())
+                    act_targets.update(mw.gwtargets[gw])
                 if act_targets:
+                    act_tgt_ns = NodeSet.fromlist(act_targets)
                     display.vprint_err(VERB_QUIET,
                                        "clush: [tree] in progress(%d) on %s: %s"
-                                       % (len(act_targets), gw, act_targets))
+                                       % (len(act_targets), gw, act_tgt_ns))
         else:
             cmdl = cmd.lower()
             try:

--- a/lib/ClusterShell/CLI/Clush.py
+++ b/lib/ClusterShell/CLI/Clush.py
@@ -418,7 +418,8 @@ class RunTimer(EventHandler):
             # tree mode
             act_targets = NodeSet()
             for gw, (chan, metaworkers) in self.task.gateways.items():
-                act_targets.updaten(mw.gwtargets[gw] for mw in metaworkers)
+                act_targets.updaten(mw.gwtargets[gw].copy()
+                                    for mw in metaworkers)
             cnt = len(act_targets) + len(self.task._engine.clients()) - gwcnt
             gwinfo = ' gw %d' % gwcnt
         else:
@@ -597,8 +598,11 @@ def ttyloop(task, nodeset, timeout, display, remote, trytree):
                                    % (len(ns_reg), ns_reg, pending,
                                       len(gws), NodeSet._fromlist1(gws)))
             for gw, (chan, metaworkers) in task.gateways.items():
-                act_targets = NodeSet.fromlist(mw.gwtargets[gw]
-                                               for mw in metaworkers)
+                act_targets = NodeSet()
+                for mw in metaworkers:
+                    # Compute active targets using updaten() from a copy of the
+                    # original sets as they might be frequently modified
+                    act_targets.updaten(mw.gwtargets[gw].copy())
                 if act_targets:
                     display.vprint_err(VERB_QUIET,
                                        "clush: [tree] in progress(%d) on %s: %s"

--- a/lib/ClusterShell/Worker/Tree.py
+++ b/lib/ClusterShell/Worker/Tree.py
@@ -351,7 +351,7 @@ class TreeWorker(DistantWorker):
 
         self._target_count += len(targets)
 
-        self.gwtargets.setdefault(str(gateway), NodeSet()).add(targets)
+        self.gwtargets.setdefault(str(gateway), set()).update(targets)
 
         # tar commands are built here and launched on targets
         if reverse:
@@ -377,7 +377,8 @@ class TreeWorker(DistantWorker):
 
         self._target_count += len(targets)
 
-        self.gwtargets.setdefault(str(gateway), NodeSet()).add(targets)
+        # GH#560: use set instead of NodeSet to keep track of active targets
+        self.gwtargets.setdefault(str(gateway), set()).update(targets)
 
         pchan = self.task._pchannel(gateway, self)
         pchan.shell(nodes=targets, command=cmd, worker=self, timeout=timeout,
@@ -396,8 +397,7 @@ class TreeWorker(DistantWorker):
         self.logger.debug("_relaunch on targets %s from previous_gateway %s",
                           targets, previous_gateway)
 
-        for target in targets:
-            self.gwtargets[previous_gateway].remove(target)
+        self.gwtargets[previous_gateway].difference_update(targets)
 
         self._check_fini(previous_gateway)
         self._target_count -= len(targets)

--- a/lib/ClusterShell/Worker/Tree.py
+++ b/lib/ClusterShell/Worker/Tree.py
@@ -393,7 +393,7 @@ class TreeWorker(DistantWorker):
         previous_gateway must be defined. However, it is not guaranteed that
         the relaunch is going to be performed using gateways (that's a feature).
         """
-        targets = self.gwtargets[previous_gateway].copy()
+        targets = NodeSet.fromlist(self.gwtargets[previous_gateway])
         self.logger.debug("_relaunch on targets %s from previous_gateway %s",
                           targets, previous_gateway)
 

--- a/tests/CLIClushTest.py
+++ b/tests/CLIClushTest.py
@@ -880,3 +880,28 @@ class CLIClushTest_D_StdinFIFO(unittest.TestCase):
         s = "%s: ok\n" % HOSTNAME
         self._clush_t(["-w", HOSTNAME, "-v", "echo ok"], None,
                       s.encode(), 0, b"")
+
+
+class CLIClushTest_E_Topology(unittest.TestCase):
+    """Unit test class for testing CLI/Clush.py with --topology"""
+
+    def setUp(self):
+        self.topofile = make_temp_file(dedent("""
+                        [Main]
+                        %s: localhost
+                        localhost: remote-node"""% HOSTNAME).encode())
+
+    def tearDown(self):
+        self.topofile = None
+
+    def _clush_t(self, args, stdin, expected_stdout, expected_rc=0,
+                 expected_stderr=None):
+        CLI_main(self, main, ['clush'] + args, stdin, expected_stdout,
+                 expected_rc, expected_stderr)
+
+    @unittest.skipIf(HOSTNAME == 'localhost', "does not work with hostname set to 'localhost'")
+    def test_300_topology(self):
+        """test clush --topology"""
+        # GH#560: to detect set!=NodeSet for gwtargets
+        self._clush_t(["--topology", self.topofile.name,
+                       "-w", "remote-node", "-b", "-v", "sleep 1; echo ok"], None, b"", 0, b"")


### PR DESCRIPTION
Using a NodeSet to track a large and frequent-changing set of remote
targets can lead to performance issue as reported in #560, especially
when RangeSetND is involved.

Use a standard set instead for gwtargets tracking in the TreeWorker
and adapt clush to work with sets in that case.

Fixes #560