### PR TITLE
bash completions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include ChangeLog
 include README.md
 include COPYING.LGPLv2.1
+include bash_completion.d/*
 include conf/*.conf
 include conf/*.example
 include conf/clush.conf.d/README

--- a/bash_completion.d/cluset
+++ b/bash_completion.d/cluset
@@ -1,0 +1,79 @@
+# cluset bash completion
+#
+# to install in /usr/share/bash-completion/completions/ or ~/.local/share/bash-completion/completions/
+_cluset()
+{
+	# shellcheck disable=SC2034 # set/used by _init_completion
+	local cur prev words cword split
+	local word options="" skip=argv0 groupsource="" cleangroup=""
+
+	_init_completion -s -n : || return
+
+	# stop parsing if there had been any non-option before (or --)
+	for word in "${words[@]}"; do
+		case "$skip" in
+		"") ;;
+		groupsource)
+			groupsource="$word"
+			;& # fallthrough
+		*)
+			skip=""
+			continue
+			;;
+		esac
+		case "$word" in
+		"") ;;
+		--) return;;
+		# no-arg options
+		--version|-h|--help|-n|--nostdin|-a|--all|-q|--quiet|\
+		-v|--verbose|-d|--debug) ;;
+		# get source separately...
+		--groupsource=*) groupsource="${word#*=}";;
+		-s|--groupsource) skip=groupsource;;
+		# assume all the rest as options...
+		# options with = included in word
+		--*=*) ;;
+		-*) skip=any;;
+		*) return;; # was non-option
+		esac
+	done
+
+	case "$prev" in
+	-c|--count|-e|--expand|-f|--fold|\
+	-x|--exclude|-i|--intersection|-X|--xor)
+		case "$cur" in
+		*:*)
+			groupsource="${cur%%:*}"
+			groupsource="${groupsource#@}"
+			;;
+		*)
+			if [ -n "$groupsource" ]; then
+				cleangroup=1
+			fi
+			;;
+		esac
+		options="$(cluset ${groupsource:+-s "$groupsource"} --completion @*)"
+		if [ -n "$cleangroup" ]; then
+			options=${options//@"$groupsource":/@}
+		fi
+		;;
+	-s|--groupsource)
+		options=$(cluset --groupsources --quiet)
+		;;
+	# no-arg options
+	--version|-h|--help|-l|--list|-L|--list-all|-r|--regroup|\
+	--list-sources|--groupsources|-d|--debug|-q|--quiet|\
+	-R|--rangeset|-G|--groupbase|--contiguous) ;;
+	# any other option: just ignore.
+	-*)
+		return;;
+	esac
+	# get all options from help text... not 100% accurate but good enough.
+	[ -n "$options" ] || options="$(cluset --help | grep -oP -- '(?<=[ \t])(-[a-z]|--[^= \t]*)')"
+
+	# append space for everything that doesn't end in `:` (likely a groupsource)
+	mapfile -t COMPREPLY < <(compgen -W "$options" -- "$cur" | sed -e 's/[^:]$/& /')
+	# remove the prefix from COMPREPLY if $cur contains colons and
+	# COMP_WORDBREAKS splits on colons...
+	__ltrim_colon_completions "$cur"
+} && complete -o nospace -F _cluset ${BASH_SOURCE##*/}

--- a/bash_completion.d/clush
+++ b/bash_completion.d/clush
@@ -1,0 +1,91 @@
+# clush bash completion
+#
+# to install in /usr/share/bash-completion/completions/ or ~/.local/share/bash-completion/completions/
+_clush()
+{
+	# shellcheck disable=SC2034 # set/used by _init_completion
+	local cur prev words cword split
+	local word options="" compopts="" skip=argv0 groupsource="" cleangroup=""
+
+	_init_completion -s -n : || return
+
+	# stop parsing if there had been any non-option before (or --)
+	for word in "${words[@]}"; do
+		case "$skip" in
+		"") ;;
+		groupsource)
+			groupsource="$word"
+			;& # fallthrough
+		*)
+			skip=""
+			continue
+			;;
+		esac
+		case "$word" in
+		"") ;;
+		--) return;;
+		# no-arg options
+		--version|-h|--help|-n|--nostdin|-a|--all|-q|--quiet|\
+		-v|--verbose|-d|--debug) ;;
+		# get source separately...
+		--groupsource=*) groupsource="${word#*=}";;
+		-s|--groupsource) skip=groupsource;;
+		# assume all the rest as options...
+		# options with = included in word
+		--*=*) ;;
+		-*) skip=any;;
+		*) return;; # was non-option
+		esac
+	done
+
+	case "$prev" in
+	-w|-x|-g|--group|-X)
+		case "$cur" in
+		*:*)
+			groupsource="${cur%%:*}"
+			groupsource="${groupsource#@}"
+			;;
+		*)
+			if [ -n "$groupsource" ]; then
+				cleangroup=1
+			fi
+			;;
+		esac
+		if [ "$prev" = "-w" ]; then
+			compopts="@*"  # include all nodes
+		fi
+		options="$(cluset ${groupsource:+-s "$groupsource"} --completion $compopts)"
+		if [ -n "$cleangroup" ]; then
+			options=${options//@"$groupsource":/@}
+		fi
+		case "$prev" in
+		-g|--group|-X)
+			options=${options//@/}
+			;;
+		esac
+		;;
+	-s|--groupsource)
+		options=$(cluset --groupsources --quiet)
+		;;
+	--color)
+		options="never always auto"
+		;;
+	-R|--worker)
+		options="ssh exec rsh"
+		;;
+	# no-arg options
+	--version|-h|--help|-n|--nostdin|-a|--all|-q|--quiet|\
+	-v|--verbose|-d|--debug) ;;
+	# any other option: just ignore.
+	-*)
+		return;;
+	esac
+	# get all options from help text... not 100% accurate but good enough.
+	[ -n "$options" ] || options="$(clush --help | grep -oP -- '(?<=[ \t])(-[a-z]|--[^= \t]*)')"
+
+	# append space for everything that doesn't end in `:` (likely a groupsource)
+	mapfile -t COMPREPLY < <(compgen -W "$options" -- "$cur" | sed -e 's/[^:]$/& /')
+	# remove the prefix from COMPREPLY if $cur contains colons and
+	# COMP_WORDBREAKS splits on colons...
+	__ltrim_colon_completions "$cur"
+} && complete -o nospace -F _clush ${BASH_SOURCE##*/}

--- a/clustershell.spec.in
+++ b/clustershell.spec.in
@@ -27,6 +27,8 @@
 %define py2 1
 %endif
 
+%{!?bash_completions_dir: %global bash_completions_dir %{_datadir}/bash-completion/completions}
+
 %global srcname ClusterShell
 
 Name:           clustershell
@@ -149,6 +151,13 @@ install -p -m 0644 doc/extras/vim/syntax/clushconf.vim %{buildroot}/%{vimdatadir
 install -p -m 0644 doc/extras/vim/syntax/groupsconf.vim %{buildroot}/%{vimdatadir}/syntax/
 %{?suse_version:%fdupes %{buildroot}}
 
+install -d %{buildroot}%{bash_completions_dir}
+install -p -m 0644 bash_completion.d/cluset -t %{buildroot}%{bash_completions_dir}
+install -p -m 0644 bash_completion.d/clush -t %{buildroot}%{bash_completions_dir}
+pushd %{buildroot}%{bash_completions_dir}
+ln -s cluset nodeset
+popd
+
 %if 0%{?rhel}
 %clean
 rm -rf %{buildroot}
@@ -228,6 +237,9 @@ rm -rf %{buildroot}
 %{vimdatadir}/ftdetect/clustershell.vim
 %{vimdatadir}/syntax/clushconf.vim
 %{vimdatadir}/syntax/groupsconf.vim
+%{bash_completions_dir}/cluset
+%{bash_completions_dir}/clush
+%{bash_completions_dir}/nodeset
 
 %changelog
 * Fri Sep 29 2023 Stephane Thiell <sthiell@stanford.edu> 1.9.2-1

--- a/lib/ClusterShell/CLI/OptionParser.py
+++ b/lib/ClusterShell/CLI/OptionParser.py
@@ -280,6 +280,10 @@ class OptionParser(optparse.OptionParser):
                           default=False,
                           help="list all active group sources (see "
                                "groups.conf(5))")
+        # special hidden command for bash completion scripts
+        optgrp.add_option("--completion", action="store_true",
+                          dest="completion",
+                          default=False, help=optparse.SUPPRESS_HELP)
         self.add_option_group(optgrp)
 
     def install_nodeset_operations(self):

--- a/tests/CLINodesetTest.py
+++ b/tests/CLINodesetTest.py
@@ -741,6 +741,17 @@ class CLINodesetGroupResolverTest2(CLINodesetTestBase):
         self._nodeset_t(["-s", "other", "--autostep=3", "-f", "*!*[033-099/2]"],
                         None, b"nova[030-032,034-100/2,101-489]\n")
 
+    def test_041_completion(self):
+        """test nodeset --completion"""
+        self._nodeset_t(["--completion"], None,
+                        b"@test:\n@other:\n@bar\n@foo\n@moo\n")
+        self._nodeset_t(["--completion", "node1", "node2"], None,
+                        b"@test:\n@other:\n@bar\n@foo\n@moo\nnode1 node2\n")
+        self._nodeset_t(["-s", "other", "--completion"], None,
+                        b"@other:baz\n@other:norf\n@other:qux\n")
+        self._nodeset_t(["-s", "other", "--completion", "node1", "node2"], None,
+                        b"@other:baz\n@other:norf\n@other:qux\nnode1 node2\n")
+
 
 class CLINodesetGroupResolverTest3(CLINodesetTestBase):
     """Unit test class for testing CLI/Nodeset.py with custom Group Resolver


### PR DESCRIPTION
Just clush for now; might be some bugs but seems to work.

perf-wise it calls `cluset -L` on every tab, we might need to cache the result somewhere if it is slow in some setups.
(But if user changes conf files it won't be reloaded so that's a bit annoying, it's better not to cache if it's reasonable e.g. just reading the conf files)


Prereq patch makes `cluset -s foo -L` not list `foo` groups with the `@foo:` prefix, like default source with `-L` -- this allows `clush -s foo -w @bar` to complete properly.