### PR TITLE
GitHub Actions: update actions to their latest versions

### DIFF
--- a/.github/workflows/nosetests.yml
+++ b/.github/workflows/nosetests.yml
@@ -14,9 +14,9 @@ jobs:
             python-version: '3.6'
     name: Tests with Python ${{ matrix.python-version }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5.2.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
This is to address the warning about deprecated Node.js