### PR TITLE
Communication: sax parser: add flush() after feed() (#556)

### DIFF
--- a/lib/ClusterShell/Communication.py
+++ b/lib/ClusterShell/Communication.py
@@ -229,6 +229,8 @@ class Channel(EventHandler):
 
         try:
             self._parser.feed(msg + b'\n')
+            if hasattr(self._parser, 'flush'):  # GH#556
+                self._parser.flush()
         except SAXParseException as ex:
             self.logger.error("SAXParseException: %s: %s", ex.getMessage(), msg)
             # Warning: do not send malformed raw message back


### PR DESCRIPTION
This is due to libexpat 2.6 reparse deferral as documented in #556.

Unfortunately ExpatParser doesn't seem to have SetReparseDeferralEnabled(), so we use an explicit flush() call to make sure all handlers are called immediately. We control the source XML.

NOTE: Only available in Python 3.13 and backports.