### PR TITLE
CLI/Nodeset: omit @source: prefix for cluset -s source -L (#563)

### DIFF
--- a/lib/ClusterShell/CLI/Nodeset.py
+++ b/lib/ClusterShell/CLI/Nodeset.py
@@ -136,8 +136,9 @@ def command_list(options, xset, group_resolver):
     if options.listall:
         # useful: sources[0] is always the default or selected source
         sources = group_resolver.sources()
-        # do not print name of default group source unless -s specified
-        if sources and not options.groupsource:
+        # do not print the name of the current group source (either the default
+        # or the one specified by -s)
+        if sources:
             sources[0] = None
     else:
         sources = [options.groupsource]

--- a/tests/CLINodesetTest.py
+++ b/tests/CLINodesetTest.py
@@ -721,7 +721,7 @@ class CLINodesetGroupResolverTest2(CLINodesetTestBase):
         self._nodeset_t(["-GL"], None,
                         b"@bar\n@foo\n@moo\n@baz\n@norf\n@qux\n")
         self._nodeset_t(["--list-all", "-s", "other"], None,
-                        b"@other:baz\n@other:norf\n@other:qux\n@test:bar\n@test:foo\n@test:moo\n")
+                        b"@baz\n@norf\n@qux\n@test:bar\n@test:foo\n@test:moo\n")
         self._nodeset_t(["--list-all", "-G", "-s", "other"], None,
                         b"@baz\n@norf\n@qux\n@bar\n@foo\n@moo\n") # 'other' source first
 


### PR DESCRIPTION
Let -s source behave as if it replaces the default group source, and thus omit the source prefix for the groups in that source.

Part of #563.