### PR TITLE
completion: handle , in node list

### DIFF
--- a/bash_completion.d/cluset
+++ b/bash_completion.d/cluset
@@ -41,6 +41,35 @@ _cluset()
 	case "$prev" in
 	-c|--count|-e|--expand|-f|--fold|\
 	-x|--exclude|-i|--intersection|-X|--xor)
+		local orig="$cur"
+		# split words (by ,-not-in-brackets and &)
+		# Note completions with & are mostly borked
+		while true; do
+			case "$cur" in
+			*"&"*)
+				# cannot handle & without some bash-completion-fu,
+				# because it tries to simplify &'s escaping and then
+				# fails as that splits commands... Just give up.
+				return
+				;;
+			*"["*"]"*,*)
+				# complete set, remove one word
+				cur="${cur#*,}"
+				;;
+			*"["*)
+				# open bracket: leave as is
+				break
+				;;
+			*,*)
+				# no brackets, remove one word
+				cur="${cur#*,}"
+				;;
+			*)
+				# nothing left to do
+				break
+				;;
+			esac
+		done
 		case "$cur" in
 		*:*)
 			groupsource="${cur%%:*}"
@@ -55,6 +84,11 @@ _cluset()
 		options="$(cluset ${groupsource:+-s "$groupsource"} --completion @*)"
 		if [ -n "$cleangroup" ]; then
 			options=${options//@"$groupsource":/@}
+		fi
+		if [ "$orig" != "$cur" ]; then
+			local prefix=${orig%$cur}
+			options="$prefix${options//$'\n'/&"$prefix"}"
+			cur="$orig"
 		fi
 		;;
 	-s|--groupsource)

--- a/bash_completion.d/clush
+++ b/bash_completion.d/clush
@@ -40,6 +40,35 @@ _clush()
 
 	case "$prev" in
 	-w|-x|-g|--group|-X)
+		local orig="$cur"
+		# split words (by ,-not-in-brackets and &)
+		# Note completions with & are mostly borked
+		while true; do
+			case "$cur" in
+			*"&"*)
+				# cannot handle & without some bash-completion-fu,
+				# because it tries to simplify &'s escaping and then
+				# fails as that splits commands... Just give up.
+				return
+				;;
+			*"["*"]"*,*)
+				# complete set, remove one word
+				cur="${cur#*,}"
+				;;
+			*"["*)
+				# open bracket: leave as is
+				break
+				;;
+			*,*)
+				# no brackets, remove one word
+				cur="${cur#*,}"
+				;;
+			*)
+				# nothing left to do
+				break
+				;;
+			esac
+		done
 		case "$cur" in
 		*:*)
 			groupsource="${cur%%:*}"
@@ -63,6 +92,11 @@ _clush()
 			options=${options//@/}
 			;;
 		esac
+		if [ "$orig" != "$cur" ]; then
+			local prefix=${orig%$cur}
+			options="$prefix${options//$'\n'/&"$prefix"}"
+			cur="$orig"
+		fi
 		;;
 	-s|--groupsource)
 		options=$(cluset --groupsources --quiet)


### PR DESCRIPTION
Split when multiple words are given to properly find matching nodes or groups:
- get last partial nodeset
- complete as if that was the current argument
- then re-add the prefix for compword to match

==========

This is a bit too ugly for my taste so I tried doing the handling in cluset --complete, something like this is a start:
```
+        # --completion "$cur" (optional groups to complete)
+        if len(args) < 1:
+            return
+        cur_arg = args[0]
+        # try to get the last "word" from 'cur', for union/intersection:
+        # remove anything that doesn't contain a [, or contain both [ and ]
+        match = re.match(r'([^,[]*(\[[^]]*])?[,&])*(.*)', cur_arg)
+        if match:
+            cur = match.group(3)
+            prefix = cur_arg.removesuffix(cur)
+        else:
+            cur = cur_arg
+            prefix = ''
```
but even if we have this, it's printing completion suggestions through regular list and expand commands so we cannot really pre-match/add prefix as I would have liked to do, so here we are :/

Happy to say 1.9.3 gets completion only on first word, and we can work this through later if someone feels the need to...
When using node names directly with different prefixes it is rather handy (e.g. `clush -w foo1,bar3,moo4`) but I don't think that's a major usecase.