### PR TITLE
doc/txt: fix clustershell.rst for pypi

### DIFF
--- a/doc/txt/clustershell.rst
+++ b/doc/txt/clustershell.rst
@@ -6,9 +6,6 @@ execution algorithms, as well as gathering results and merging identical
 outputs, or retrieving return codes. ClusterShell takes advantage of existing
 remote shell facilities already installed on your systems, like SSH.
 
-User tools
-----------
-
 ClusterShell provides clush, clubak and cluset/nodeset, convenient command-line
 tools that allow traditional shell scripts to benefit from some of the
 library's features:


### PR DESCRIPTION
PROBLEM:

$ twine check --strict dist/*
Checking dist/ClusterShell-1.9.3.tar.gz: FAILED
ERROR    `long_description` has syntax errors in markup and would not be rendered on PyPI.
         line 10: Severe: Unexpected section title.

         User tools
         ----------
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.