### PR TITLE
Get CI off of about-to-be-removed Ubuntu 20.04

### DIFF
--- a/.github/workflows/nosetests.yml
+++ b/.github/workflows/nosetests.yml
@@ -10,8 +10,6 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         include:
-          - os: ubuntu-20.04
-            python-version: '3.6'
           - os: ubuntu-22.04
             python-version: '3.7'
     name: Tests with Python ${{ matrix.python-version }}


### PR DESCRIPTION
Because of https://github.com/actions/runner-images/issues/11101