### PR TITLE
Tree: implement TreeWorker.abort() (#229)

### DIFF
--- a/lib/ClusterShell/Communication.py
+++ b/lib/ClusterShell/Communication.py
@@ -218,7 +218,6 @@ class Channel(EventHandler):
     def ev_read(self, worker, node, sname, msg):
         """channel has data to read"""
         # sname can be either SNAME_READER or self.SNAME_ERROR
-
         if sname == self.SNAME_ERROR:
             if self.initiator:
                 self.recv(StdErrMessage(node, msg))

--- a/lib/ClusterShell/Propagation.py
+++ b/lib/ClusterShell/Propagation.py
@@ -251,7 +251,6 @@ class PropagationChannel(Channel):
         """process incoming messages"""
         self.logger.debug("recv: %s", msg)
         if msg.type == EndMessage.ident:
-            #??#self.ptree.notify_close()
             self.logger.debug("got EndMessage; closing")
             self._close()
         elif msg.type == StdErrMessage.ident and msg.srcid == 0:


### PR DESCRIPTION
Now that the TreeWorker code allows us to abort commands per gateway channel, we can implement a more general TreeWorker.abort() method. This method aborts all direct workers and also commands handled via gateways.

Closes #229.