### PR TITLE
Tree: invoke _ev_routing() on relaunch and add tests

### DIFF
--- a/lib/ClusterShell/Communication.py
+++ b/lib/ClusterShell/Communication.py
@@ -139,6 +139,7 @@ class XMLReader(ContentHandler):
             StdErrMessage.ident: StdErrMessage,
             RetcodeMessage.ident: RetcodeMessage,
             TimeoutMessage.ident: TimeoutMessage,
+            RoutingMessage.ident: RoutingMessage,
         }
         try:
             msg_type = attributes['type']
@@ -456,6 +457,19 @@ class TimeoutMessage(RoutedMessageBase):
         RoutedMessageBase.__init__(self, srcid)
         self.attr.update({'nodes': str})
         self.nodes = nodes
+
+class RoutingMessage(RoutedMessageBase):
+    """container message for routing notification"""
+    ident = 'RTR'
+
+    def __init__(self, event='', gateway='', targets='', srcid=0):
+        """
+        """
+        RoutedMessageBase.__init__(self, srcid)
+        self.attr.update({'event': str, 'gateway': str, 'targets': str})
+        self.event = event
+        self.gateway = gateway
+        self.targets = targets
 
 class StartMessage(Message):
     """message indicating the start of a channel communication"""

--- a/lib/ClusterShell/Gateway.py
+++ b/lib/ClusterShell/Gateway.py
@@ -40,7 +40,7 @@ from ClusterShell.Worker.Tree import TreeWorker
 from ClusterShell.Communication import Channel, ConfigurationMessage, \
     ControlMessage, ACKMessage, ErrorMessage, StartMessage, EndMessage, \
     StdOutMessage, StdErrMessage, RetcodeMessage, TimeoutMessage, \
-    MessageProcessingError
+    RoutingMessage, MessageProcessingError
 
 
 def _gw_print_debug(task, line):
@@ -147,6 +147,14 @@ class TreeWorkerResponder(EventHandler):
             # finalize grooming
             self.ev_timer(None)
             self.timer.invalidate()
+
+    def _ev_routing(self, worker, arg):
+        """
+        Routing event (private). Called to indicate that a (meta)worker has just
+        updated one of its route path.
+        """
+        self.logger.debug("TreeWorkerResponder: ev_routing arg=%s", arg)
+        self.gwchan.send(RoutingMessage(**arg, srcid=self.srcwkr))
 
 
 class GatewayChannel(Channel):

--- a/lib/ClusterShell/Propagation.py
+++ b/lib/ClusterShell/Propagation.py
@@ -29,12 +29,12 @@ import logging
 
 from ClusterShell.Defaults import DEFAULTS
 from ClusterShell.NodeSet import NodeSet
-from ClusterShell.Communication import Channel
-from ClusterShell.Communication import ControlMessage, StdOutMessage
-from ClusterShell.Communication import StdErrMessage, RetcodeMessage
-from ClusterShell.Communication import StartMessage, EndMessage
-from ClusterShell.Communication import RoutedMessageBase, ErrorMessage
-from ClusterShell.Communication import ConfigurationMessage, TimeoutMessage
+from ClusterShell.Communication import (Channel, ControlMessage, StdOutMessage,
+                                        StdErrMessage, RetcodeMessage,
+                                        StartMessage, EndMessage,
+                                        RoutedMessageBase, ErrorMessage,
+                                        ConfigurationMessage, TimeoutMessage,
+                                        RoutingMessage)
 from ClusterShell.Topology import TopologyError
 
 
@@ -376,19 +376,17 @@ class PropagationChannel(Channel):
                 self.logger.debug("TimeoutMessage for %s", msg.nodes)
                 for node in NodeSet(msg.nodes):
                     metaworker._on_remote_node_timeout(node, self.gateway)
+            elif msg.type == RoutingMessage.ident:
+                self.logger.debug("RoutingMessage for %s (gw %s)", msg.targets,
+                                  msg.gateway)
+                metaworker._on_routing_event({ "event": msg.event,
+                                               "gateway": msg.gateway,
+                                               "targets": msg.targets })
         elif msg.type == ErrorMessage.ident:
             # tree runtime error, could generate a new event later
             raise TopologyError("%s: %s" % (self.gateway, msg.reason))
         else:
             self.logger.debug("recv_ctl: unhandled msg %s", msg)
-        """
-        return
-        if self.ptree.upchannel is not None:
-            self.logger.debug("_state_gather ->upchan %s" % msg)
-            self.ptree.upchannel.send(msg) # send to according event handler passed by shell()
-        else:
-            assert False
-        """
 
     def ev_hup(self, worker, node, rc):
         """Channel command is closing"""


### PR DESCRIPTION
EventHandler._ev_routing() has been defined since CS 1.6 or so, but was never called. It can be used by the user program to get notified for tree related propagation events. For now it is relatively simple and we only generate "reroute" events when a gateway is failing and commands are tentatively redistributed to other gateways.

Note that with this change, the parents nodes need to be upgraded first, otherwise they won't understand the new RoutingMessage coming from the gateways.