### PR TITLE
Clush: handle _ev_routing reroute events

### DIFF
--- a/lib/ClusterShell/CLI/Clush.py
+++ b/lib/ClusterShell/CLI/Clush.py
@@ -134,6 +134,14 @@ class OutputHandler(EventHandler):
         if self._runtimer:
             self._runtimer.eh.bytes_written += size
 
+    def _ev_routing(self, worker, arg):
+        prefix = "clush: "
+        self._display.vprint_err(VERB_DEBUG, prefix + "_ev_routing: %s" % arg)
+        if "reroute" in arg.get("event", ""):
+            info_fmt = "rerouting commands for {targets} due to the failure " \
+                       "of gateway {gateway}"
+            self._display.vprint_err(VERB_STD, prefix + info_fmt.format(**arg))
+
 class DirectOutputHandler(OutputHandler):
     """Direct output event handler class."""
 


### PR DESCRIPTION
Display gateway reroute events. Can be quieted with -q.