### PR TITLE
Tree: improve handling of MessageProcessingError

### DIFF
--- a/tests/TreeGatewayTest.py
+++ b/tests/TreeGatewayTest.py
@@ -256,13 +256,18 @@ class TreeGatewayTest(TreeGatewayBaseTest):
     def test_err_unknown_msg(self):
         """test gateway unknown message"""
         self._check_channel_err('<message msgid="24" type="ABC"></message>',
-                                'Unknown message type',
+                                'Unknown message type ABC',
                                 openchan=False)
 
     def test_channel_err_unknown_msg(self):
         """test gateway channel unknown message"""
         self._check_channel_err('<message msgid="24" type="ABC"></message>',
-                                'Unknown message type')
+                                'Unknown message type ABC')
+
+    def test_channel_err_no_type_msg(self):
+        """test gateway channel message with no type"""
+        self._check_channel_err('<message msgid="24"></message>',
+                                'Unknown message with no type')
 
     def test_err_xml_malformed(self):
         """test gateway malformed xml message"""

--- a/tests/TreeGatewayTest.py
+++ b/tests/TreeGatewayTest.py
@@ -269,6 +269,11 @@ class TreeGatewayTest(TreeGatewayBaseTest):
         self._check_channel_err('<message msgid="24"></message>',
                                 'Unknown message with no type')
 
+    def test_channel_err_empty_type_msg(self):
+        """test gateway channel message with empty type"""
+        self._check_channel_err('<message msgid="24" type=""></message>',
+                                'Unknown message with no type')
+
     def test_err_xml_malformed(self):
         """test gateway malformed xml message"""
         self._check_channel_err('<message type="ABC"</message>',


### PR DESCRIPTION
Better error handling for unsupported messages in the gateway channel (MessageProcessingError).