### PR TITLE
Add no-arg options -b and -B to bash_completion.d/clush

### DIFF
--- a/bash_completion.d/clush
+++ b/bash_completion.d/clush
@@ -64,8 +64,7 @@ _clush()
 		-w|-g|--group) target_set=1; skip=any;;
 		# no-arg options
 		--version|-h|--help|-n|--nostdin|-a|--all|-q|--quiet|\
-		-b|-B|\
-		-v|--verbose|-d|--debug) ;;
+		-b|-B|-v|--verbose|-d|--debug) ;;
 		# get source separately...
 		--groupsource=*) groupsource="${word#*=}";;
 		-s|--groupsource) skip=groupsource;;

--- a/bash_completion.d/clush
+++ b/bash_completion.d/clush
@@ -64,6 +64,7 @@ _clush()
 		-w|-g|--group) target_set=1; skip=any;;
 		# no-arg options
 		--version|-h|--help|-n|--nostdin|-a|--all|-q|--quiet|\
+		-b|-B|\
 		-v|--verbose|-d|--debug) ;;
 		# get source separately...
 		--groupsource=*) groupsource="${word#*=}";;


### PR DESCRIPTION
We mostly user the ```clush -b <args>``` option to aggregate output from our cluster nodes or other groups of nodes.
We also use the Bash TAB completions added by PR #563 and part of the 1.9.3 release which we install as an EL8 RPM from EPEL.

However, combining ```clush -b -g<TAB><TAB>``` doesn't seem to work, whereas ```clush -g<TAB><TAB> -b``` works just fine.

I think this issue is fixed by adding no-arg options ```-b``` and ```-B``` to ```bash_completion.d/clush```.

Thanks,
Ole