### PR TITLE
GitHub Actions: migrate from nosetests to unittest

### DIFF
--- a/.github/workflows/nosetests.yml
+++ b/.github/workflows/nosetests.yml
@@ -1,4 +1,4 @@
-name: ClusterShell nosetests
+name: ClusterShell tests
 
 on: [push, pull_request, merge_group]
 
@@ -21,27 +21,36 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        set -euxo pipefail
         python -m pip install --upgrade pip
-        pip install coverage nose-py3 .
+        pip install coverage .
     - name: Allow us to SSH passwordless to localhost
       run: |
+        set -euxo pipefail
         chmod og-rw ~
         ssh-keygen -f ~/.ssh/id_rsa -N ""
         cp ~/.ssh/{id_rsa.pub,authorized_keys}
     - name: Avoid ssh "known hosts" warnings
       run: |
+        set -euxo pipefail
         printf '%s\n    %s\n    %s\n' 'Host *' 'StrictHostKeyChecking no' 'LogLevel ERROR' >> ~/.ssh/config
     - name: Set Python paths when sshing for gateway tests
       run: |
+        set -euxo pipefail
+        PYTHON_SITE_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
         sed -i "1iexport CLUSTERSHELL_GW_PYTHON_EXECUTABLE=$(which python)" ~/.bashrc
-        sed -i "2iexport PYTHONPATH=\$PYTHONPATH:$(realpath $pythonLocation/lib/python*/site-packages)" ~/.bashrc
-        head -2 ~/.bashrc
+        sed -i "2iexport PYTHONPATH=\$PYTHONPATH:$PYTHON_SITE_PACKAGES" ~/.bashrc
+        head -3 ~/.bashrc
+        ssh 127.0.0.2 'python -c "import ClusterShell; print(ClusterShell.__file__)"'
     - name: Install pdsh to test WorkerPdsh
       run: |
+        set -euxo pipefail
+        sudo apt-get update
         sudo apt-get -y install pdsh
         sudo sh -c 'echo ssh > /etc/pdsh/rcmd_default'
     - name: Add tests/bin to remote PATH
       run: |
+        set -euxo pipefail
         sed -i "1iexport PATH=$PWD/tests/bin:\$PATH" ~/.bashrc
         head -1 ~/.bashrc
         ssh 127.0.0.2 which hostname
@@ -78,9 +87,11 @@ jobs:
     - name: Run tests
       id: tests
       run: |
+        set -euxo pipefail
         python --version
         export CLUSTERSHELL_GW_PYTHON_EXECUTABLE=$(which python)
-        nosetests -v --all-modules --with-coverage --cover-tests --cover-erase --cover-package=ClusterShell tests
+        coverage run --branch --source=ClusterShell -m unittest discover -v -s tests -p '*Test.py' -t .
+        coverage report -m
     - name: Post to Slack (end)
       if: always()
       continue-on-error: true

--- a/tests/CLIClubakTest.py
+++ b/tests/CLIClubakTest.py
@@ -7,7 +7,7 @@ import re
 from textwrap import dedent
 import unittest
 
-from TLib import *
+from .TLib import *
 from ClusterShell.CLI.Clubak import main
 
 from ClusterShell.NodeSet import set_std_group_resolver, \

--- a/tests/CLIClushTest.py
+++ b/tests/CLIClushTest.py
@@ -20,7 +20,7 @@ import unittest
 
 from subprocess import Popen, PIPE
 
-from TLib import *
+from .TLib import *
 import ClusterShell.CLI.Clush
 from ClusterShell.CLI.Clush import main
 from ClusterShell.NodeSet import NodeSet
@@ -443,10 +443,11 @@ class CLIClushTest_A(unittest.TestCase):
         curdir = os.getcwd()
         try:
             os.chdir(tdir.name)
-            s = "Warning: using '-w %s' and local path '%s' exists, was it " \
-                "expanded by the shell?\n" % (HOSTNAME, HOSTNAME)
+            s = b"Warning: using '-w %s' and local path '%s' exists, was it " \
+                b"expanded by the shell?\n" % (HOSTNAME.encode(), HOSTNAME.encode())
+            # Use regex to match start of stderr, allowing for additional warnings
             self._clush_t(["-w", HOSTNAME, "echo", "ok"], None,
-                          self.output_ok, 0, s.encode())
+                          self.output_ok, 0, re.compile(re.escape(s)))
         finally:
             os.chdir(curdir)
             tfile.close()

--- a/tests/CLIConfigTest.py
+++ b/tests/CLIConfigTest.py
@@ -10,7 +10,7 @@ import tempfile
 from textwrap import dedent
 import unittest
 
-from TLib import *
+from .TLib import *
 
 from ClusterShell.CLI.Clush import set_fdlimit
 from ClusterShell.CLI.Config import ClushConfig, ClushConfigError

--- a/tests/CLINodesetTest.py
+++ b/tests/CLINodesetTest.py
@@ -8,7 +8,7 @@ import random
 from textwrap import dedent
 import unittest
 
-from TLib import *
+from .TLib import *
 from ClusterShell.CLI.Nodeset import main
 
 from ClusterShell.NodeUtils import GroupResolverConfig

--- a/tests/DefaultsTest.py
+++ b/tests/DefaultsTest.py
@@ -10,7 +10,7 @@ import shutil
 from textwrap import dedent
 import unittest
 
-from TLib import make_temp_file, make_temp_dir
+from .TLib import make_temp_file, make_temp_dir
 
 from ClusterShell.Defaults import Defaults, _task_print_debug
 

--- a/tests/MisusageTest.py
+++ b/tests/MisusageTest.py
@@ -5,7 +5,7 @@
 
 import unittest
 
-from TLib import HOSTNAME
+from .TLib import HOSTNAME
 from ClusterShell.Event import EventHandler
 from ClusterShell.Worker.Popen import WorkerPopen
 from ClusterShell.Worker.Ssh import WorkerSsh

--- a/tests/NodeSetGroupTest.py
+++ b/tests/NodeSetGroupTest.py
@@ -8,7 +8,7 @@ import sys
 from textwrap import dedent
 import unittest
 
-from TLib import *
+from .TLib import *
 
 # Wildcard import for testing purpose
 from ClusterShell.NodeSet import *

--- a/tests/TaskDistantMixin.py
+++ b/tests/TaskDistantMixin.py
@@ -7,7 +7,7 @@ import pwd
 import unittest
 import warnings
 
-from TLib import HOSTNAME, make_temp_filename, make_temp_dir
+from .TLib import HOSTNAME, make_temp_filename, make_temp_dir
 from ClusterShell.Event import EventHandler
 from ClusterShell.Task import *
 from ClusterShell.Worker.Ssh import WorkerSsh

--- a/tests/TaskDistantPdshMixin.py
+++ b/tests/TaskDistantPdshMixin.py
@@ -3,7 +3,7 @@
 
 """Unit test for ClusterShell Task (distant, pdsh worker)"""
 
-from TLib import HOSTNAME, make_temp_filename, make_temp_dir
+from .TLib import HOSTNAME, make_temp_filename, make_temp_dir
 from ClusterShell.Event import EventHandler
 from ClusterShell.Task import *
 from ClusterShell.Worker.Worker import WorkerBadArgumentError

--- a/tests/TaskDistantPdshTest.py
+++ b/tests/TaskDistantPdshTest.py
@@ -11,7 +11,7 @@ from ClusterShell.Engine.Poll import EnginePoll
 from ClusterShell.Engine.EPoll import EngineEPoll
 from ClusterShell.Task import *
 
-from TaskDistantPdshMixin import TaskDistantPdshMixin
+from .TaskDistantPdshMixin import TaskDistantPdshMixin
 
 ENGINE_SELECT_ID = EngineSelect.identifier
 ENGINE_POLL_ID = EnginePoll.identifier

--- a/tests/TaskDistantTest.py
+++ b/tests/TaskDistantTest.py
@@ -11,7 +11,7 @@ from ClusterShell.Engine.Poll import EnginePoll
 from ClusterShell.Engine.EPoll import EngineEPoll
 from ClusterShell.Task import *
 
-from TaskDistantMixin import TaskDistantMixin
+from .TaskDistantMixin import TaskDistantMixin
 
 ENGINE_SELECT_ID = EngineSelect.identifier
 ENGINE_POLL_ID = EnginePoll.identifier

--- a/tests/TaskLocalTest.py
+++ b/tests/TaskLocalTest.py
@@ -11,7 +11,7 @@ from ClusterShell.Engine.Poll import EnginePoll
 from ClusterShell.Engine.EPoll import EngineEPoll
 from ClusterShell.Task import *
 
-from TaskLocalMixin import TaskLocalMixin
+from .TaskLocalMixin import TaskLocalMixin
 
 ENGINE_SELECT_ID = EngineSelect.identifier
 ENGINE_POLL_ID = EnginePoll.identifier

--- a/tests/TaskRLimitsTest.py
+++ b/tests/TaskRLimitsTest.py
@@ -6,7 +6,7 @@
 import resource
 import unittest
 
-from TLib import HOSTNAME
+from .TLib import HOSTNAME
 from ClusterShell.Task import *
 from ClusterShell.Worker.Pdsh import WorkerPdsh
 

--- a/tests/TaskTimerTest.py
+++ b/tests/TaskTimerTest.py
@@ -8,7 +8,7 @@ import threading
 from time import sleep, time
 import unittest
 
-from TLib import HOSTNAME
+from .TLib import HOSTNAME
 from ClusterShell.Engine.Engine import EngineTimer, EngineIllegalOperationError
 from ClusterShell.Event import EventHandler
 from ClusterShell.Task import *

--- a/tests/TreeGatewayTest.py
+++ b/tests/TreeGatewayTest.py
@@ -19,7 +19,7 @@ from ClusterShell.Topology import TopologyGraph
 from ClusterShell.Worker.Tree import TreeWorker
 from ClusterShell.Worker.Worker import StreamWorker
 
-from TLib import HOSTNAME
+from .TLib import HOSTNAME
 
 # live logging with nosetests --nologcapture
 logging.basicConfig(level=logging.DEBUG)

--- a/tests/TreeTaskTest.py
+++ b/tests/TreeTaskTest.py
@@ -11,7 +11,7 @@ from ClusterShell.Propagation import RouteResolvingError
 from ClusterShell.Task import task_self
 from ClusterShell.Topology import TopologyError
 
-from TLib import HOSTNAME, make_temp_file
+from .TLib import HOSTNAME, make_temp_file
 
 # live logging with nosetests --nologcapture
 logging.basicConfig(level=logging.DEBUG)

--- a/tests/TreeTopologyTest.py
+++ b/tests/TreeTopologyTest.py
@@ -16,7 +16,7 @@ from ClusterShell.Topology import *
 from ClusterShell.NodeSet import NodeSet, set_std_group_resolver
 from ClusterShell.NodeSet import set_std_group_resolver_config
 from ClusterShell.NodeUtils import GroupResolverConfig
-from TLib import make_temp_file
+from .TLib import make_temp_file
 
 
 class TopologyTest(unittest.TestCase):

--- a/tests/TreeWorkerTest.py
+++ b/tests/TreeWorkerTest.py
@@ -28,7 +28,7 @@ from ClusterShell.Task import Task, task_cleanup
 from ClusterShell.Topology import TopologyGraph
 from ClusterShell.Worker.Tree import TreeWorker, WorkerTree
 
-from TLib import HOSTNAME, make_temp_dir, make_temp_file, make_temp_filename
+from .TLib import HOSTNAME, make_temp_dir, make_temp_file, make_temp_filename
 
 
 NODE_HEAD = HOSTNAME

--- a/tests/WorkerExecTest.py
+++ b/tests/WorkerExecTest.py
@@ -6,7 +6,7 @@
 import os
 import unittest
 
-from TLib import HOSTNAME, make_temp_file, make_temp_filename, make_temp_dir
+from .TLib import HOSTNAME, make_temp_file, make_temp_filename, make_temp_dir
 
 from ClusterShell.Event import EventHandler
 from ClusterShell.Worker.Exec import ExecWorker, WorkerError


### PR DESCRIPTION
- Replace abandoned nose-py3 with stdlib unittest
- Update CI workflow to use 'coverage run -m unittest discover'
- Convert all test imports to package-relative imports (from .TLib import *)
- Add tests/__init__.py to make tests/ a proper Python package
- Fix test_027_warn_shell_globbing_nodes to handle Python 3.12 deprecation warnings
- Add 'set -euxo pipefail' to all workflow steps for better error handling
- Improve remote Python path detection using site.getsitepackages()