### PR TITLE
Updated documentation #604

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Documentation
 
 Online documentation is available here:
 
-    http://clustershell.readthedocs.org/
+    https://clustershell.readthedocs.io/
 
 The Sphinx documentation source is available under the doc/sphinx directory.
 Type 'make' to see all available formats (you need Sphinx installed and
@@ -90,7 +90,7 @@ Web site:
 
 Online documentation:
 
-    http://clustershell.readthedocs.org/
+    https://clustershell.readthedocs.io/
 
 Github source repository:
 

--- a/conf/groups.conf
+++ b/conf/groups.conf
@@ -1,7 +1,7 @@
 # ClusterShell node groups main configuration file
 #
 # Please see `man 5 groups.conf` and
-# http://clustershell.readthedocs.org/en/latest/config.html#node-groups
+# https://clustershell.readthedocs.io/en/latest/config.html#node-groups
 # for further details.
 #
 # NOTE: This is a simple group configuration example file, not a

--- a/doc/man/man1/clubak.1
+++ b/doc/man/man1/clubak.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "CLUBAK" "1" "2025-01-23" "1.9.3" "ClusterShell User Manual"
+.TH "CLUBAK" 1 "2025-01-23" "1.9.3" "ClusterShell User Manual"
 .SH NAME
 clubak \- format output from clush/pdsh-like output and more
 .SH SYNOPSIS
@@ -133,12 +133,12 @@ node2: 9
 .sp
 \fBcluset\fP(1), \fBclush\fP(1), \fBnodeset\fP(1), \fBgroups.conf\fP(5).
 .sp
- <http://clustershell.readthedocs.org/> 
+\fI\%https://clustershell.readthedocs.io/\fP
 .SH BUG REPORTS
 .INDENT 0.0
 .TP
 .B Use the following URL to submit a bug report or feedback:
- <https://github.com/cea\-hpc/clustershell/issues> 
+\fI\%https://github.com/cea\-hpc/clustershell/issues\fP
 .UNINDENT
 .SH AUTHOR
 Stephane Thiell <sthiell@stanford.edu>

--- a/doc/man/man1/cluset.1
+++ b/doc/man/man1/cluset.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "CLUSET" "1" "2025-01-23" "1.9.3" "ClusterShell User Manual"
+.TH "CLUSET" 1 "2025-01-23" "1.9.3" "ClusterShell User Manual"
 .SH NAME
 cluset \- compute advanced cluster node set operations
 .SH SYNOPSIS
@@ -477,12 +477,12 @@ command and also to conform with ClusterShell\(aqs \(dqclu*\(dq command nomencla
 .sp
 \fBclubak\fP(1), \fBclush\fP(1), \fBnodeset\fP(1), \fBgroups.conf\fP(5).
 .sp
- <http://clustershell.readthedocs.org/> 
+\fI\%https://clustershell.readthedocs.io/\fP
 .SH BUG REPORTS
 .INDENT 0.0
 .TP
 .B Use the following URL to submit a bug report or feedback:
- <https://github.com/cea\-hpc/clustershell/issues> 
+\fI\%https://github.com/cea\-hpc/clustershell/issues\fP
 .UNINDENT
 .SH AUTHOR
 Stephane Thiell <sthiell@stanford.edu>

--- a/doc/man/man1/clush.1
+++ b/doc/man/man1/clush.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "CLUSH" "1" "2025-01-23" "1.9.3" "ClusterShell User Manual"
+.TH "CLUSH" 1 "2025-01-23" "1.9.3" "ClusterShell User Manual"
 .SH NAME
 clush \- execute shell commands on a cluster
 .SH SYNOPSIS
@@ -408,12 +408,12 @@ File in which interactive \fBclush\fP command history is saved.
 .sp
 \fBclubak\fP(1), \fBcluset\fP(1), \fBnodeset\fP(1), \fBreadline\fP(3), \fBclush.conf\fP(5), \fBgroups.conf\fP(5).
 .sp
- <http://clustershell.readthedocs.org/> 
+\fI\%https://clustershell.readthedocs.io/\fP
 .SH BUG REPORTS
 .INDENT 0.0
 .TP
 .B Use the following URL to submit a bug report or feedback:
- <https://github.com/cea\-hpc/clustershell/issues> 
+\fI\%https://github.com/cea\-hpc/clustershell/issues\fP
 .UNINDENT
 .SH AUTHOR
 Stephane Thiell <sthiell@stanford.edu>

--- a/doc/man/man1/nodeset.1
+++ b/doc/man/man1/nodeset.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "NODESET" "1" "2025-01-23" "1.9.3" "ClusterShell User Manual"
+.TH "NODESET" 1 "2025-01-23" "1.9.3" "ClusterShell User Manual"
 .SH NAME
 nodeset \- compute advanced nodeset operations
 .SH SYNOPSIS
@@ -501,12 +501,12 @@ command and also to conform with ClusterShell\(aqs \(dqclu*\(dq command nomencla
 .sp
 \fBclubak\fP(1), \fBcluset\fP(1), \fBclush\fP(1), \fBgroups.conf\fP(5).
 .sp
- <http://clustershell.readthedocs.org/> 
+\fI\%https://clustershell.readthedocs.io/\fP
 .SH BUG REPORTS
 .INDENT 0.0
 .TP
 .B Use the following URL to submit a bug report or feedback:
- <https://github.com/cea\-hpc/clustershell/issues> 
+\fI\%https://github.com/cea\-hpc/clustershell/issues\fP
 .UNINDENT
 .SH AUTHOR
 Stephane Thiell <sthiell@stanford.edu>

--- a/doc/man/man5/clush.conf.5
+++ b/doc/man/man5/clush.conf.5
@@ -27,10 +27,13 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "CLUSH.CONF" "5" "2025-01-23" "1.9.3" "ClusterShell User Manual"
+.TH "CLUSH.CONF" 5 "2025-01-23" "1.9.3" "ClusterShell User Manual"
 .SH NAME
 clush.conf \- Configuration file for clush
 .SH DESCRIPTION
+.sp
+\fBclush\fP(1) configuration files are in Python\(aqs ConfigParser format.
+.SS Locations
 .sp
 \fBclush\fP(1) obtains configuration options from the following sources in the
 following order:
@@ -221,7 +224,11 @@ from \fIclush.conf\fP\&.  External commands whose outputs were used by \fBclush\
 .sp
 \fBclush\fP(1), \fBgroups.conf\fP(5), \fBsshpass\fP(1), \fBsudo\fP(8).
 .sp
- <http://clustershell.readthedocs.org/> 
+\fI\%https://clustershell.readthedocs.io/\fP
+.sp
+Python ConfigParser
+.sp
+\fI\%https://docs.python.org/3/library/configparser.html\fP
 .SH AUTHOR
 Stephane Thiell, <sthiell@stanford.edu>
 .SH COPYRIGHT

--- a/doc/man/man5/groups.conf.5
+++ b/doc/man/man5/groups.conf.5
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GROUPS.CONF" "5" "2025-01-23" "1.9.3" "ClusterShell User Manual"
+.TH "GROUPS.CONF" 5 "2025-01-23" "1.9.3" "ClusterShell User Manual"
 .SH NAME
 groups.conf \- Configuration file for ClusterShell node groups
 .SH DESCRIPTION
@@ -206,7 +206,7 @@ Local groups.conf user configuration file (default installation for pip \-\-user
 .sp
 \fBclubak\fP(1), \fBcluset\fP(1), \fBclush\fP(1), \fBnodeset\fP(1)
 .sp
- <http://clustershell.readthedocs.org/> 
+\fI\%https://clustershell.readthedocs.io/\fP
 .SH AUTHOR
 Stephane Thiell, <sthiell@stanford.edu>
 .SH COPYRIGHT

--- a/doc/sphinx/config.rst
+++ b/doc/sphinx/config.rst
@@ -11,6 +11,11 @@ clush
 clush.conf
 ^^^^^^^^^^
 
+The *clush.conf* files are parsed with Python's `ConfigParser`_
+
+Locations
+"""""""""
+
 The following configuration file defines system-wide default values for
 several ``clush`` tool parameters::
 
@@ -33,6 +38,12 @@ valid, it will used instead. In such case, the following configuration file
 will be tried first for ``clush``::
 
     $CLUSTERSHELL_CFGDIR/clush.conf
+
+Settings
+""""""""
+
+Settings that apply to all ``clush`` :ref:`run modes <clushmode-config>` are
+contained within the ``[Main]`` section.
 
 The following table describes available ``clush`` config file settings.
 

--- a/doc/sphinx/release.rst
+++ b/doc/sphinx/release.rst
@@ -559,7 +559,7 @@ Main changes in 1.7
 ^^^^^^^^^^^^^^^^^^^
 
 This new version comes with a refreshed documentation, based on the Sphinx
-documentation generator, available on http://clustershell.readthedocs.org.
+documentation generator, available on https://clustershell.readthedocs.io.
 
 The main new features of version 1.7 are described below.
 

--- a/doc/txt/clubak.txt
+++ b/doc/txt/clubak.txt
@@ -88,7 +88,7 @@ SEE ALSO
 
 ``cluset``\(1), ``clush``\(1), ``nodeset``\(1), ``groups.conf``\(5).
 
-http://clustershell.readthedocs.org/
+https://clustershell.readthedocs.io/
 
 BUG REPORTS
 ===========

--- a/doc/txt/cluset.txt
+++ b/doc/txt/cluset.txt
@@ -278,7 +278,7 @@ SEE ALSO
 
 ``clubak``\(1), ``clush``\(1), ``nodeset``\(1), ``groups.conf``\(5).
 
-http://clustershell.readthedocs.org/
+https://clustershell.readthedocs.io/
 
 BUG REPORTS
 ===========

--- a/doc/txt/clush.conf.txt
+++ b/doc/txt/clush.conf.txt
@@ -17,6 +17,11 @@ Configuration file for `clush`
 DESCRIPTION
 ===========
 
+``clush``\(1) configuration files are in Python's ConfigParser format.
+
+Locations
+---------
+
 ``clush``\(1) obtains configuration options from the following sources in the
 following order:
 
@@ -186,4 +191,8 @@ SEE ALSO
 
 ``clush``\(1), ``groups.conf``\(5), ``sshpass``\(1\), ``sudo``\(8\).
 
-http://clustershell.readthedocs.org/
+https://clustershell.readthedocs.io/
+
+Python ConfigParser
+
+https://docs.python.org/3/library/configparser.html

--- a/doc/txt/clush.txt
+++ b/doc/txt/clush.txt
@@ -307,7 +307,7 @@ SEE ALSO
 
 ``clubak``\(1), ``cluset``\(1), ``nodeset``\(1), ``readline``\(3), ``clush.conf``\(5), ``groups.conf``\(5).
 
-http://clustershell.readthedocs.org/
+https://clustershell.readthedocs.io/
 
 BUG REPORTS
 ===========

--- a/doc/txt/groups.conf.txt
+++ b/doc/txt/groups.conf.txt
@@ -184,4 +184,4 @@ SEE ALSO
 
 ``clubak``\(1), ``cluset``\(1), ``clush``\(1), ``nodeset``\(1)
 
-http://clustershell.readthedocs.org/
+https://clustershell.readthedocs.io/

--- a/doc/txt/nodeset.txt
+++ b/doc/txt/nodeset.txt
@@ -290,7 +290,7 @@ SEE ALSO
 
 ``clubak``\(1), ``cluset``\(1), ``clush``\(1), ``groups.conf``\(5).
 
-http://clustershell.readthedocs.org/
+https://clustershell.readthedocs.io/
 
 BUG REPORTS
 ===========

--- a/lib/ClusterShell/__init__.py
+++ b/lib/ClusterShell/__init__.py
@@ -38,4 +38,4 @@ __version__ = '1.9.3'
 __version_info__ = tuple([ int(_n) for _n in __version__.split('.')])
 __date__    = '2025/01/23'
 __author__  = 'Stephane Thiell <sthiell@stanford.edu>'
-__url__     = 'http://clustershell.readthedocs.org/'
+__url__     = 'https://clustershell.readthedocs.io/'


### PR DESCRIPTION
Updated configuration documentation to make it more explicit that clush.conf is in ConfigParser format and in the RST docs clarified that the default run-time global section as `[Main]`.

Updated references to ReadTheDocs to use both https and the current externally facing hostname.

Regenerated manpages from text sources.

Closes #604