### PR TITLE
NodeUtils: add envvars option for group source upcalls

### DIFF
--- a/doc/man/man5/groups.conf.5
+++ b/doc/man/man5/groups.conf.5
@@ -135,6 +135,13 @@ external command is avoided automatically.
 .B cache_time
 Number of seconds each upcall result is kept in cache, in memory only.
 Default is 3600 seconds. This is useful only for daemons using nodegroups.
+.TP
+.B envvars
+Optional space-separated list of \fIKEY=VALUE\fP environment variable
+assignments made available to all upcall commands of this group source.
+Shell quoting is supported for values containing spaces (eg.
+\fIMY_VAR="some value"\fP). Variables already set in the process environment
+take precedence over values defined here.
 .UNINDENT
 .sp
 When the library executes a group source external shell command, the current

--- a/doc/sphinx/config.rst
+++ b/doc/sphinx/config.rst
@@ -437,6 +437,22 @@ one-shot commands like :ref:`clush <clush-tool>` or
 
 The default value of **cache_time** is 3600 seconds.
 
+Environment variables
+"""""""""""""""""""""
+
+The optional parameter **envvars** accepts a space-separated list of
+``KEY=VALUE`` assignments that are added to the environment of all upcall
+commands in that group source section. Shell quoting is supported for values
+that contain spaces::
+
+    [ansible]
+    envvars: ANSIBLE_INVENTORY=/etc/ansible/inventory
+    map: ansible-inventory -i $ANSIBLE_INVENTORY --list ...
+
+If a variable is already set in the calling process environment, that value
+takes precedence over the one defined in **envvars**, allowing per-run
+overrides without editing the configuration file.
+
 Multiple sources section
 """"""""""""""""""""""""
 

--- a/doc/txt/groups.conf.txt
+++ b/doc/txt/groups.conf.txt
@@ -106,6 +106,12 @@ reverse
 cache_time
   Number of seconds each upcall result is kept in cache, in memory only.
   Default is 3600 seconds. This is useful only for daemons using nodegroups.
+envvars
+  Optional space-separated list of *KEY=VALUE* environment variable
+  assignments made available to all upcall commands of this group source.
+  Shell quoting is supported for values containing spaces (eg.
+  *MY_VAR="some value"*). Variables already set in the process environment
+  take precedence over values defined here.
 
 When the library executes a group source external shell command, the current
 working directory is previously set to the corresponding confdir. This

--- a/lib/ClusterShell/NodeUtils.py
+++ b/lib/ClusterShell/NodeUtils.py
@@ -168,10 +168,11 @@ class UpcallGroupSource(GroupSource):
 
     def __init__(self, name, map_upcall, all_upcall=None,
                  list_upcall=None, reverse_upcall=None, cfgdir=None,
-                 cache_time=None):
+                 cache_time=None, extra_env=None):
         GroupSource.__init__(self, name)
         self.verbosity = 0 # deprecated
         self.cfgdir = cfgdir
+        self.extra_env = extra_env or {}
         self.logger = logging.getLogger(__name__)
 
         # Supported external upcalls
@@ -209,8 +210,14 @@ class UpcallGroupSource(GroupSource):
         """
         cmdline = Template(self.upcalls[cmdtpl]).safe_substitute(args)
         self.logger.debug("EXEC '%s'", cmdline)
+        env = None
+        if self.extra_env:
+            env = os.environ.copy()
+            for key, val in self.extra_env.items():
+                if key not in os.environ:
+                    env[key] = val
         proc = Popen(cmdline, stdin=DEVNULL, stdout=PIPE, shell=True,
-                     cwd=self.cfgdir, universal_newlines=True)
+                     cwd=self.cfgdir, universal_newlines=True, env=env)
         output = proc.communicate()[0].strip()
         self.logger.debug("READ '%s'", output)
         if proc.returncode != 0:
@@ -674,12 +681,27 @@ class GroupResolverConfig(GroupResolver):
                         if cfg.has_option(section, 'cache_time'):
                             ctime = float(cfg.get(section, 'cache_time',
                                                   raw=True))
+                        extra_env = {}
+                        if cfg.has_option(section, 'envvars'):
+                            envvar_str = cfg.get(section, 'envvars', raw=True)
+                            try:
+                                for token in shlex.split(envvar_str):
+                                    if '=' not in token:
+                                        raise GroupResolverConfigError(
+                                            "envvars: invalid assignment %r"
+                                            " (missing '=')" % token)
+                                    key, val = token.split('=', 1)
+                                    extra_env[key] = val
+                            except ValueError as exc:
+                                raise GroupResolverConfigError(
+                                    "envvars: %s" % exc)
                         # add new group source
                         self.add_source(UpcallGroupSource(srcname, map_upcall,
                                                           all_upcall,
                                                           list_upcall,
                                                           reverse_upcall,
-                                                          cfgdir, ctime))
+                                                          cfgdir, ctime,
+                                                          extra_env or None))
         except (NoSectionError, NoOptionError, ValueError) as exc:
             raise GroupResolverConfigError(str(exc))
 

--- a/tests/NodeSetGroupTest.py
+++ b/tests/NodeSetGroupTest.py
@@ -1905,3 +1905,121 @@ class GroupResolverYAMLTest(unittest.TestCase):
             yamlfile.close()
             tdir.cleanup()
 
+
+class GroupSourceEnvVarTest(unittest.TestCase):
+    """Tests for the envvars option in group source upcall configuration"""
+
+    def test_envvars_basic(self):
+        """test envvars sets environment variable for upcall commands"""
+        f = make_temp_file(dedent("""
+            [local]
+            envvars: MY_TEST_VAR=node1
+            map: echo $MY_TEST_VAR
+            list: echo grp1
+            """).encode('ascii'))
+        res = GroupResolverConfig(f.name)
+        self.assertEqual(res.group_nodes('grp1'), ['node1'])
+
+    def test_envvars_multiple(self):
+        """test envvars with multiple space-separated assignments"""
+        f = make_temp_file(dedent("""
+            [local]
+            envvars: VAR_A=foo1 VAR_B=foo2
+            map: echo $VAR_A $VAR_B
+            list: echo grp1
+            """).encode('ascii'))
+        res = GroupResolverConfig(f.name)
+        self.assertEqual(sorted(res.group_nodes('grp1')), ['foo1', 'foo2'])
+
+    def test_envvars_quoted_value(self):
+        """test envvars with a shell-quoted value"""
+        f = make_temp_file(dedent("""
+            [local]
+            envvars: MY_VAR="node[1-3]"
+            map: echo "$MY_VAR"
+            list: echo grp1
+            """).encode('ascii'))
+        res = GroupResolverConfig(f.name)
+        self.assertEqual(res.group_nodes('grp1'), ['node[1-3]'])
+
+    def test_envvars_not_present(self):
+        """test that omitting envvars does not affect upcall behaviour"""
+        f = make_temp_file(dedent("""
+            [local]
+            map: echo node1
+            list: echo grp1
+            """).encode('ascii'))
+        res = GroupResolverConfig(f.name)
+        self.assertEqual(res.group_nodes('grp1'), ['node1'])
+
+    def test_envvars_no_leak(self):
+        """test envvars variables do not leak between group sources"""
+        f = make_temp_file(dedent("""
+            [Main]
+            default: src1
+
+            [src1]
+            envvars: TEST_LEAK_VAR=source1
+            map: echo $TEST_LEAK_VAR
+            list: echo grp1
+
+            [src2]
+            envvars: TEST_LEAK_VAR=source2
+            map: echo $TEST_LEAK_VAR
+            list: echo grp2
+            """).encode('ascii'))
+        res = GroupResolverConfig(f.name)
+        self.assertEqual(res.group_nodes('grp1', 'src1'), ['source1'])
+        self.assertEqual(res.group_nodes('grp2', 'src2'), ['source2'])
+
+    def test_envvars_with_group_subst(self):
+        """test envvars and $GROUP substitution work together in the same command"""
+        f = make_temp_file(dedent("""
+            [local]
+            envvars: NODE_PREFIX=foo
+            map: echo ${NODE_PREFIX}$GROUP
+            list: echo 1
+            """).encode('ascii'))
+        res = GroupResolverConfig(f.name)
+        self.assertEqual(res.group_nodes('1'), ['foo1'])
+
+    def test_envvars_inherits_path(self):
+        """test that upcall subprocess inherits PATH when envvars is set"""
+        f = make_temp_file(dedent("""
+            [local]
+            envvars: MY_VAR=ok
+            map: sh -c 'test -n "$PATH" && echo $MY_VAR || echo fail'
+            list: echo grp1
+            """).encode('ascii'))
+        res = GroupResolverConfig(f.name)
+        self.assertEqual(res.group_nodes('grp1'), ['ok'])
+
+    def test_envvars_env_overrides_conf(self):
+        """test that process environment takes precedence over envvars in config"""
+        f = make_temp_file(dedent("""
+            [local]
+            envvars: CS_TEST_OVERRIDE=conf_value
+            map: echo $CS_TEST_OVERRIDE
+            list: echo grp1
+            """).encode('ascii'))
+        orig = os.environ.pop('CS_TEST_OVERRIDE', None)
+        try:
+            os.environ['CS_TEST_OVERRIDE'] = 'env_value'
+            res = GroupResolverConfig(f.name)
+            self.assertEqual(res.group_nodes('grp1'), ['env_value'])
+        finally:
+            del os.environ['CS_TEST_OVERRIDE']
+            if orig is not None:
+                os.environ['CS_TEST_OVERRIDE'] = orig
+
+    def test_envvars_malformed(self):
+        """test that an envvars token without = raises GroupResolverConfigError"""
+        f = make_temp_file(dedent("""
+            [local]
+            envvars: NOT_VALID
+            map: echo node1
+            list: echo grp1
+            """).encode('ascii'))
+        resolver = GroupResolverConfig(f.name)
+        self.assertRaises(GroupResolverConfigError, resolver.group_nodes, 'grp1')
+


### PR DESCRIPTION
Adds an optional envvars key to groups.conf.d source sections. It accepts a space-separated list of KEY=VALUE assignments (shell quoting supported) that are injected into the subprocess environment for all upcall commands of that source. Variables already present in the calling process environment take precedence, allowing per-run overrides without editing the config file.
```
  [ansible]
  envvars: ANSIBLE_INVENTORY=/path/to/inventory
  map: ansible-inventory -i $ANSIBLE_INVENTORY --list ...
```