### PR TITLE
conf: add Ansible inventory group source example

### DIFF
--- a/conf/groups.conf.d/ansible.conf.example
+++ b/conf/groups.conf.d/ansible.conf.example
@@ -1,0 +1,25 @@
+# Additional ClusterShell group source config file
+#
+# Please see `man 5 groups.conf` for further details.
+#
+
+# Ansible inventory bindings
+#
+# Requirements: ansible-core (provides ansible-inventory), jq
+#
+# Replace /path/to/inventory with your inventory path or directory,
+# or set ANSIBLE_INVENTORY in your environment to override it.
+#
+[ansible]
+
+# Resolve group members, recursing into child groups
+map: ANSIBLE_INVENTORY="${ANSIBLE_INVENTORY:-/path/to/inventory}" ansible-inventory --list 2>/dev/null | jq -r --arg g "$GROUP" 'def r(d;g): (d[g].hosts//[])[], ((d[g].children//[])[] as $c | r(d;$c)); r(.;$g)'
+
+# Resolve all groups in a single call, recursing into child groups
+mapall: ANSIBLE_INVENTORY="${ANSIBLE_INVENTORY:-/path/to/inventory}" ansible-inventory --list 2>/dev/null | jq -r 'def r(d;g): (d[g].hosts//[])[], ((d[g].children//[])[] as $c | r(d;$c)); . as $d | keys[] | select(. != "_meta" and . != "all" and (test("[[:space:]:]") | not)) | "\(.): \([r($d;.)] | join(" "))"'
+
+# All inventory hosts
+all: ANSIBLE_INVENTORY="${ANSIBLE_INVENTORY:-/path/to/inventory}" ansible-inventory --list 2>/dev/null | jq -r '.[].hosts // empty | .[]'
+
+# All groups
+list: ANSIBLE_INVENTORY="${ANSIBLE_INVENTORY:-/path/to/inventory}" ansible-inventory --list 2>/dev/null | jq -r 'keys[] | select(. != "_meta" and . != "all")'

--- a/doc/sphinx/config.rst
+++ b/doc/sphinx/config.rst
@@ -712,6 +712,54 @@ Example of use with :ref:`cluset-tool`::
 
 .. highlight:: text
 
+.. _group-ansible-bindings:
+
+Ansible inventory group bindings
+"""""""""""""""""""""""""""""""""
+
+Enable Ansible inventory group bindings by renaming the example configuration
+file usually installed as
+``/etc/clustershell/groups.conf.d/ansible.conf.example`` to ``ansible.conf``.
+
+**Requirements**: ``ansible-core`` (provides the ``ansible-inventory`` command)
+and ``jq``.
+
+The section **ansible** defines a group source backed by Ansible inventory.
+Each upcall command uses ``ANSIBLE_INVENTORY`` as an inline environment variable
+prefix so that multiple inventory sources (comma-separated paths) are supported.
+The default path defined in the configuration file is used as a fallback when
+``$ANSIBLE_INVENTORY`` is not set in the environment::
+
+    ANSIBLE_INVENTORY="${ANSIBLE_INVENTORY:-/path/to/inventory}" ansible-inventory --list ...
+
+The example upcalls resolve hosts to their Ansible ``inventory_hostname`` rather
+than the ``ansible_host`` connection address, so names from non-resolvable
+aliases (e.g. with dynamic inventory) are not directly usable with
+:ref:`clush-tool`. These commands can be adapted to your inventory as needed,
+for instance to emit ``ansible_host`` instead.
+
+The ``mapall`` upcall resolves every group in a single ``ansible-inventory
+--list`` call. As ``--list`` always dumps the whole inventory regardless of the
+group being queried, this avoids running one ``ansible-inventory`` command per
+group when listing or resolving several groups at once (e.g. ``nodeset -ll``).
+Group names that contain ``:`` or whitespace cannot be expressed in the
+``mapall`` output format; they are skipped from ``mapall`` and resolved through
+the ``map`` upcall instead, so they still resolve but do not appear in
+``nodeset -l`` output.
+
+.. highlight:: console
+
+Example of use with :ref:`nodeset-tool` on a cluster managed with Ansible::
+
+    $ nodeset -s ansible -l
+    @ansible:db
+    @ansible:web
+    @ansible:web_prod
+    @ansible:web_test
+    $ clush -w @ansible:web uptime
+
+.. highlight:: text
+
 .. _defaults-config:
 
 Library Defaults


### PR DESCRIPTION
Provides a groups.conf.d example for using Ansible inventory as a ClusterShell group source via ansible-inventory and jq. Supports map (with recursive child group resolution), mapall, all, and list upcalls.

`ansible-inventory --list` always dumps the whole inventory regardless of the queried group, so the per-group `map` upcall already pays the full-dump cost. The `mapall` upcall (#613) exploits this to resolve every group in a single call — e.g. `nodeset -ll` drops from one `ansible-inventory` invocation per group to one. Group names containing `:` or whitespace are skipped from mapall and resolved through `map`.

The inventory path is taken from `$ANSIBLE_INVENTORY` if set, otherwise from the `/path/to/inventory` placeholder, so it can be exported once in the environment (supporting comma-separated inventories) or edited directly in the file.
