### PR TITLE
NodeUtils: add mapall upcall to get all group mappings in one call

### DIFF
--- a/doc/man/man5/groups.conf.5
+++ b/doc/man/man5/groups.conf.5
@@ -65,7 +65,7 @@ Global configuration options. There should be only one Main section.
 .B \fIGroup_source\fP
 The \fIGroup_source\fP section(s) define the configuration for each node group
 source (or namespace). This configuration consists in external commands
-definition (map, all, list and reverse).
+definition (map, mapall, all, list and reverse).
 .UNINDENT
 .sp
 Only \fIGroup_source\fP section(s) are allowed in additional configuration files.
@@ -111,7 +111,23 @@ Configuration parameters of each group source section are described below.
 Specify the external shell command used to resolve a group name into a
 nodeset, list of nodes or list of nodeset (separated by space characters or
 by carriage returns). The variable \fI$GROUP\fP is replaced before executing the
-command.
+command. Either \fBmap\fP or \fBmapall\fP must be defined.
+.TP
+.B mapall
+Optional external shell command that should return all group\-to\-nodes
+mappings for this group source in a single call, one \fIgroup: nodes\fP line
+per group. Useful when the source can dump all its groups at once (eg.
+with \fIsinfo\fP or \fIansible\-inventory \-\-list\fP), as a single call then serves
+both \fBmap\fP and \fBlist\fP queries from the cache. \fBmapall\fP output takes
+precedence over the \fBlist\fP upcall. If \fBmap\fP is also defined, it is
+used as a fallback for groups missing from the \fBmapall\fP output (or all
+groups if caching is disabled); otherwise, missing groups resolve to an
+empty nodeset.
+The first \fB:\fP on each line separates the group name from the nodes, so
+group names must be single words without \fB:\fP\&. Duplicate group lines are
+merged. A malformed output line makes the whole \fBmapall\fP call fail
+(nothing is cached and the next query retries), and a failing \fBmapall\fP
+command does not fall back to \fBmap\fP\&.
 .TP
 .B all
 Optional external shell command that should return a nodeset, list of
@@ -122,7 +138,7 @@ external command in the same group source followed by \fBmap\fP for each group.
 .B list
 Optional external shell command that should return the list of all groups
 for this group source (separated by space characters or by carriage
-returns).
+returns). Not used when \fBmapall\fP is defined, unless caching is disabled.
 .TP
 .B reverse
 Optional external shell command used to find the group(s) of a single

--- a/doc/sphinx/config.rst
+++ b/doc/sphinx/config.rst
@@ -286,7 +286,7 @@ The *groups.conf* files are parsed with Python's `ConfigParser`_:
     Duplicate directory paths are ignored.
 
 * Each following section (`genders`, `slurm`) defines a  group source. The
-  map, all, list and reverse upcalls are explained below in
+  map, mapall, all, list and reverse upcalls are explained below in
   :ref:`group-sources-upcalls`.
 
 .. _group-file-based:
@@ -388,11 +388,26 @@ Group source upcalls
 """"""""""""""""""""
 
 Each node group source is defined by a section name (*source* name) and up to
-four upcalls:
+five upcalls:
 
 * **map**: External shell command used to resolve a group name into a node
   set, list of nodes or list of node sets (separated by space characters or by
-  carriage returns). The variable *$GROUP* is replaced before executing the command.
+  carriage returns). The variable *$GROUP* is replaced before executing the
+  command. Either **map** or **mapall** must be defined.
+* **mapall**: Optional external shell command that should return all
+  group-to-nodes mappings for this group source in a single call, one
+  ``group: nodes`` line per group. Useful when the source can dump all its
+  groups at once (eg. with ``sinfo`` or ``ansible-inventory --list``), as a
+  single call then serves both **map** and **list** queries from the cache.
+  **mapall** output takes precedence over the **list** upcall. If **map** is
+  also defined, it is used as a fallback for groups missing from the
+  **mapall** output (or all groups if caching is disabled); otherwise,
+  missing groups resolve to an empty node set.
+  The first ``:`` on each line separates the group name from the nodes, so
+  group names must be single words without ``:``. Duplicate group lines are
+  merged. A malformed output line makes the whole **mapall** call fail
+  (nothing is cached and the next query retries), and a failing **mapall**
+  command does not fall back to **map**.
 * **all**: Optional external shell command that should return a node set, list
   of nodes or list of node sets of all nodes for this group source. If not
   specified, the library will try to resolve all nodes by using the **list**
@@ -401,9 +416,11 @@ four upcalls:
   by the special group name ``@*`` (or ``@source:*``).
 * **list**: Optional external shell command that should return the list of all
   groups for this group source (separated by space characters or by carriage
-  returns). If this upcall is not specified, ClusterShell won't be able to
-  list any available groups (eg. with ``nodeset -l``), so it is highly
-  recommended to set it.
+  returns). This upcall is not used when **mapall** is defined (unless
+  caching is disabled), as the group list is then derived from its output.
+  If neither **list** nor **mapall** is specified, ClusterShell won't be
+  able to list any available groups (eg. with ``nodeset -l``), so it is
+  highly recommended to set one of them.
 * **reverse**: Optional external shell command used to find the group(s) of a
   single node. The variable *$NODE* is previously replaced. If this external
   call is not specified, the reverse operation is computed in memory by the
@@ -411,6 +428,14 @@ four upcalls:
   the number of nodes to reverse is greater than the number of available
   groups, the reverse external command is avoided automatically to reduce
   resolution time.
+
+.. highlight:: ini
+
+Example of a Slurm partition group source defined with a single **mapall**
+upcall, instead of separate **map** and **list** upcalls::
+
+    [slurmpart,sp]
+    mapall: sinfo -h -o "%R: %N"
 
 In addition to context-dependent *$GROUP* and *$NODE* variables described
 above, the two following variables are always available and also replaced

--- a/doc/txt/groups.conf.txt
+++ b/doc/txt/groups.conf.txt
@@ -40,7 +40,7 @@ Main
 *Group_source*
   The *Group_source* section(s) define the configuration for each node group
   source (or namespace). This configuration consists in external commands
-  definition (map, all, list and reverse).
+  definition (map, mapall, all, list and reverse).
 
 Only *Group_source* section(s) are allowed in additional configuration files.
 
@@ -86,7 +86,22 @@ map
   Specify the external shell command used to resolve a group name into a
   nodeset, list of nodes or list of nodeset (separated by space characters or
   by carriage returns). The variable *$GROUP* is replaced before executing the
-  command.
+  command. Either ``map`` or ``mapall`` must be defined.
+mapall
+  Optional external shell command that should return all group-to-nodes
+  mappings for this group source in a single call, one *group: nodes* line
+  per group. Useful when the source can dump all its groups at once (eg.
+  with *sinfo* or *ansible-inventory --list*), as a single call then serves
+  both ``map`` and ``list`` queries from the cache. ``mapall`` output takes
+  precedence over the ``list`` upcall. If ``map`` is also defined, it is
+  used as a fallback for groups missing from the ``mapall`` output (or all
+  groups if caching is disabled); otherwise, missing groups resolve to an
+  empty nodeset.
+  The first ``:`` on each line separates the group name from the nodes, so
+  group names must be single words without ``:``. Duplicate group lines are
+  merged. A malformed output line makes the whole ``mapall`` call fail
+  (nothing is cached and the next query retries), and a failing ``mapall``
+  command does not fall back to ``map``.
 all
   Optional external shell command that should return a nodeset, list of
   nodes or list of nodeset of all nodes for this group source. If not
@@ -95,7 +110,7 @@ all
 list
   Optional external shell command that should return the list of all groups
   for this group source (separated by space characters or by carriage
-  returns).
+  returns). Not used when ``mapall`` is defined, unless caching is disabled.
 reverse
   Optional external shell command used to find the group(s) of a single
   node. The variable $NODE is previously replaced. If this upcall is not

--- a/lib/ClusterShell/NodeUtils.py
+++ b/lib/ClusterShell/NodeUtils.py
@@ -164,11 +164,15 @@ class UpcallGroupSource(GroupSource):
 
     Upcall results are cached for a customizable amount of time. This is
     controlled by `cache_time` attribute. Default is 3600 seconds.
+
+    The optional 'mapall' upcall returns all group-to-nodes mappings in a
+    single call and is then used to serve both 'map' and 'list' queries
+    from the cache.
     """
 
-    def __init__(self, name, map_upcall, all_upcall=None,
+    def __init__(self, name, map_upcall=None, all_upcall=None,
                  list_upcall=None, reverse_upcall=None, cfgdir=None,
-                 cache_time=None):
+                 cache_time=None, mapall_upcall=None):
         GroupSource.__init__(self, name)
         self.verbosity = 0 # deprecated
         self.cfgdir = cfgdir
@@ -176,7 +180,8 @@ class UpcallGroupSource(GroupSource):
 
         # Supported external upcalls
         self.upcalls = {}
-        self.upcalls['map'] = map_upcall
+        if map_upcall:
+            self.upcalls['map'] = map_upcall
         if all_upcall:
             self.upcalls['all'] = all_upcall
         if list_upcall:
@@ -184,6 +189,8 @@ class UpcallGroupSource(GroupSource):
         if reverse_upcall:
             self.upcalls['reverse'] = reverse_upcall
             self.has_reverse = True
+        if mapall_upcall:
+            self.upcalls['mapall'] = mapall_upcall
 
         # Cache upcall data
         if cache_time is None:
@@ -227,9 +234,6 @@ class UpcallGroupSource(GroupSource):
         If `key' is missing, it is added to provided `cache'. Each entry in a
         cache is kept only for a limited time equal to self.cache_time .
         """
-        if not self.upcalls.get(upcall):
-            raise GroupSourceNoUpcall(upcall, self)
-
         # Purge expired data from cache
         if key in cache and cache[key][1] < time.time():
             self.logger.debug("PURGE EXPIRED (%d)'%s'", cache[key][1], key)
@@ -237,6 +241,9 @@ class UpcallGroupSource(GroupSource):
 
         # Fetch the data if unknown of just purged
         if key not in cache:
+            if not self.upcalls.get(upcall):
+                raise GroupSourceNoUpcall(upcall, self)
+
             cache_expiry = time.time() + self.cache_time
             # $CFGDIR and $SOURCE always replaced
             args['CFGDIR'] = self.cfgdir
@@ -245,11 +252,52 @@ class UpcallGroupSource(GroupSource):
 
         return cache[key][0]
 
+    def _populate_from_mapall(self):
+        """
+        Run the optional 'mapall' upcall and fill the map and list caches
+        from its output. No-op if 'mapall' is not defined or its last
+        result is still fresh.
+        """
+        if 'mapall' not in self.upcalls:
+            return
+        cached = self._cache.get('mapall')
+        if cached is not None and cached[1] >= time.time():
+            return
+
+        content = self._upcall_cache('mapall', self._cache, 'mapall')
+        cache_expiry = self._cache['mapall'][1]
+        new_map = {}
+        try:
+            for line in content.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                group, sep, nodes = line.partition(':')
+                group = group.strip()
+                if not sep or not group or len(group.split()) > 1:
+                    raise GroupSourceQueryFailed(
+                        "mapall: invalid line %r (expected 'group: nodes')"
+                        % line, self)
+                nodes = nodes.strip()
+                if group in new_map:
+                    # union duplicate group lines, like multi-line map output
+                    nodes = ','.join(n for n in (new_map[group][0], nodes) if n)
+                new_map[group] = (nodes, cache_expiry)
+        except GroupSourceQueryFailed:
+            del self._cache['mapall'] # do not keep unusable output
+            raise
+        self._cache['map'] = new_map
+        self._cache['list'] = (' '.join(new_map), cache_expiry)
+
     def resolv_map(self, group):
         """
         Get nodes from group 'group', using the cached value if
         available.
         """
+        self._populate_from_mapall()
+        if 'map' not in self.upcalls and 'mapall' in self.upcalls:
+            # no map fallback: unknown group resolves to an empty node set
+            return self._cache['map'].get(group, ('',))[0]
         return self._upcall_cache('map', self._cache['map'], group, GROUP=group)
 
     def resolv_list(self):
@@ -257,6 +305,10 @@ class UpcallGroupSource(GroupSource):
         Return a list of all group names for this group source, using
         the cached value if available.
         """
+        self._populate_from_mapall()
+        if 'list' not in self.upcalls and 'mapall' in self.upcalls:
+            # no list fallback: read mapall result directly (cache_time 0)
+            return self._cache['list'][0]
         return self._upcall_cache('list', self._cache, 'list')
 
     def resolv_all(self):
@@ -661,9 +713,20 @@ class GroupResolverConfig(GroupResolver):
                 # Support grouped sections: section1,section2,section3
                 for srcname in section.split(','):
                     if srcname != self.SECTION_MAIN:
-                        # only map is a mandatory upcall
-                        map_upcall = cfg.get(section, 'map', raw=True)
+                        # map or mapall is a mandatory upcall
+                        if not cfg.has_option(section, 'map') and \
+                           not cfg.has_option(section, 'mapall'):
+                            raise GroupResolverConfigError(
+                                "No option 'map' or 'mapall' in section: %r"
+                                % section)
+
+                        map_upcall = mapall_upcall = None
                         all_upcall = list_upcall = reverse_upcall = ctime = None
+                        if cfg.has_option(section, 'map'):
+                            map_upcall = cfg.get(section, 'map', raw=True)
+                        if cfg.has_option(section, 'mapall'):
+                            mapall_upcall = cfg.get(section, 'mapall',
+                                                    raw=True)
                         if cfg.has_option(section, 'all'):
                             all_upcall = cfg.get(section, 'all', raw=True)
                         if cfg.has_option(section, 'list'):
@@ -675,11 +738,10 @@ class GroupResolverConfig(GroupResolver):
                             ctime = float(cfg.get(section, 'cache_time',
                                                   raw=True))
                         # add new group source
-                        self.add_source(UpcallGroupSource(srcname, map_upcall,
-                                                          all_upcall,
-                                                          list_upcall,
-                                                          reverse_upcall,
-                                                          cfgdir, ctime))
+                        self.add_source(UpcallGroupSource(
+                            srcname, map_upcall, all_upcall, list_upcall,
+                            reverse_upcall, cfgdir, ctime,
+                            mapall_upcall=mapall_upcall))
         except (NoSectionError, NoOptionError, ValueError) as exc:
             raise GroupResolverConfigError(str(exc))
 

--- a/tests/NodeSetGroupTest.py
+++ b/tests/NodeSetGroupTest.py
@@ -1366,6 +1366,9 @@ class StaticGroupSource(UpcallGroupSource):
     """
 
     def __init__(self, name, data):
+        map_upcall = None
+        if 'map' in data:
+            map_upcall = 'fake_map'
         all_upcall = None
         if 'all' in data:
             all_upcall = 'fake_all'
@@ -1375,8 +1378,12 @@ class StaticGroupSource(UpcallGroupSource):
         reverse_upcall = None
         if 'reverse' in data:
             reverse_upcall = 'fake_reverse'
-        UpcallGroupSource.__init__(self, name, "fake_map", all_upcall,
-                                   list_upcall, reverse_upcall)
+        mapall_upcall = None
+        if 'mapall' in data:
+            mapall_upcall = 'fake_mapall'
+        UpcallGroupSource.__init__(self, name, map_upcall, all_upcall,
+                                   list_upcall, reverse_upcall,
+                                   mapall_upcall=mapall_upcall)
         self._data = data
 
     def _upcall_read(self, cmdtpl, args=dict()):
@@ -1460,6 +1467,242 @@ class GroupSourceCacheTest(unittest.TestCase):
         dummy = res.group_nodes('dummy')  # init res to access res._sources
         self.assertEqual(res._sources['local'].cache_time, 0.2)
         self.assertEqual("foo1", str(NodeSet("@local:foo", resolver=res)))
+
+
+class GroupSourceMapallTest(unittest.TestCase):
+    """Tests for the optional 'mapall' bulk upcall (issue #612)."""
+
+    def test_mapall_basic(self):
+        """test UpcallGroupSource with only a mapall upcall"""
+        source = StaticGroupSource('m', {
+            'mapall': "a: foo1\nb: foo2\nc: foo[3-4]\n",
+        })
+        res = GroupResolver(source)
+        self.assertEqual("foo1", str(NodeSet("@a", resolver=res)))
+        self.assertEqual("foo2", str(NodeSet("@b", resolver=res)))
+        self.assertEqual("foo[3-4]", str(NodeSet("@c", resolver=res)))
+        # list is also derived from mapall output
+        self.assertEqual(sorted(res.grouplist()), ['a', 'b', 'c'])
+        # unknown group resolves to empty (no map upcall available)
+        self.assertEqual("", str(NodeSet("@nope", resolver=res)))
+
+    def test_mapall_with_map_fallback(self):
+        """test mapall + map: missing group falls back to per-group map"""
+        source = StaticGroupSource('mm', {
+            'mapall': "a: foo1\n",
+            'map': {'b': 'foo2'},
+        })
+        res = GroupResolver(source)
+        self.assertEqual("foo1", str(NodeSet("@a", resolver=res)))
+        # 'b' not in mapall output: falls back to map upcall
+        self.assertEqual("foo2", str(NodeSet("@b", resolver=res)))
+        # 'b' is now cached via map
+        self.assertIn('a', source._cache['map'])
+        self.assertIn('b', source._cache['map'])
+
+    def test_mapall_overrides_list(self):
+        """test that mapall output takes precedence over the list upcall"""
+        source = StaticGroupSource('ml', {
+            'mapall': "a: n1\n",
+            'list': "explicit_only",  # disagrees with mapall on purpose
+        })
+        source.cache_time = 0.2
+        res = GroupResolver(source)
+        self.assertEqual(['a'], list(res.grouplist()))
+        time.sleep(0.25)
+        # precedence holds across a cache refresh cycle
+        self.assertEqual(['a'], list(res.grouplist()))
+
+    def test_mapall_expiry(self):
+        """test that mapall is re-run when cache_time expires"""
+        source = StaticGroupSource('me', {
+            'mapall': "a: v1\nold: x1\n",
+        })
+        source.cache_time = 0.2
+        res = GroupResolver(source)
+        self.assertEqual("v1", str(NodeSet("@a", resolver=res)))
+        self.assertEqual("x1", str(NodeSet("@old", resolver=res)))
+        # change underlying mapall output, sleep past expiry
+        source._data['mapall'] = "a: v2\nb: v3\n"
+        time.sleep(0.25)
+        self.assertEqual("v2", str(NodeSet("@a", resolver=res)))
+        self.assertEqual("v3", str(NodeSet("@b", resolver=res)))
+        # map cache was swapped, not merged: removed group is gone
+        self.assertEqual("", str(NodeSet("@old", resolver=res)))
+        # list cache is also refreshed from mapall output
+        self.assertEqual(sorted(res.grouplist()), ['a', 'b'])
+
+    def test_mapall_clear_cache(self):
+        """test that clear_cache() triggers a new mapall call"""
+        source = StaticGroupSource('mc', {
+            'mapall': "a: v1\n",
+        })
+        res = GroupResolver(source)
+        self.assertEqual("v1", str(NodeSet("@a", resolver=res)))
+        source._data['mapall'] = "a: v2\n"
+        self.assertEqual("v1", str(NodeSet("@a", resolver=res)))
+        source.clear_cache()
+        self.assertEqual("v2", str(NodeSet("@a", resolver=res)))
+
+    def test_mapall_cache_time_zero(self):
+        """test mapall-only source with cache_time set to 0 (no caching)"""
+        source = StaticGroupSource('m0', {
+            'mapall': "a: n1\n",
+        })
+        source.cache_time = 0
+        res = GroupResolver(source)
+        self.assertEqual(['a'], list(res.grouplist()))
+        self.assertEqual("n1", str(NodeSet("@a", resolver=res)))
+        # no caching: updated mapall output is seen right away
+        source._data['mapall'] = "a: n2\nb: n3\n"
+        self.assertEqual("n2", str(NodeSet("@a", resolver=res)))
+        self.assertEqual(sorted(res.grouplist()), ['a', 'b'])
+
+    def test_mapall_empty_group(self):
+        """test mapall line with no nodes resolves to empty"""
+        source = StaticGroupSource('mz', {
+            'mapall': "empty:\nfilled: n1\n",
+        })
+        res = GroupResolver(source)
+        self.assertEqual("", str(NodeSet("@empty", resolver=res)))
+        self.assertEqual("n1", str(NodeSet("@filled", resolver=res)))
+
+    def test_mapall_empty_output(self):
+        """test mapall upcall returning no groups at all"""
+        source = StaticGroupSource('mo', {
+            'mapall': "",
+        })
+        res = GroupResolver(source)
+        self.assertEqual([], list(res.grouplist()))
+        self.assertEqual("", str(NodeSet("@nope", resolver=res)))
+
+    def test_mapall_blank_lines_ignored(self):
+        """test mapall tolerates blank lines and surrounding whitespace"""
+        source = StaticGroupSource('mb', {
+            'mapall': "\n  a: n1 \n\n  b: n2\n\n",
+        })
+        res = GroupResolver(source)
+        self.assertEqual("n1", str(NodeSet("@a", resolver=res)))
+        self.assertEqual("n2", str(NodeSet("@b", resolver=res)))
+
+    def test_mapall_parse_error(self):
+        """test mapall line without ':' raises GroupSourceQueryFailed"""
+        source = StaticGroupSource('mp', {
+            'mapall': "a: n1\nbroken_no_colon\n",
+        })
+        res = GroupResolver(source)
+        self.assertRaises(GroupSourceQueryFailed, res.group_nodes, 'a')
+
+    def test_mapall_empty_group_name(self):
+        """test mapall line with empty group name raises GroupSourceQueryFailed"""
+        source = StaticGroupSource('mpe', {
+            'mapall': ": n1\n",
+        })
+        res = GroupResolver(source)
+        self.assertRaises(GroupSourceQueryFailed, res.group_nodes, 'a')
+
+    def test_mapall_whitespace_group_name(self):
+        """test mapall line with multi-word group name raises GroupSourceQueryFailed"""
+        source = StaticGroupSource('mpw', {
+            'mapall': "bad group: n1\n",
+        })
+        res = GroupResolver(source)
+        self.assertRaises(GroupSourceQueryFailed, res.group_nodes, 'a')
+
+    def test_mapall_duplicate_groups_union(self):
+        """test that duplicate mapall group lines are unioned"""
+        source = StaticGroupSource('mu', {
+            'mapall': "a: n1\nb: n3\na: n2\na:\n",
+        })
+        res = GroupResolver(source)
+        self.assertEqual("n[1-2]", str(NodeSet("@a", resolver=res)))
+        self.assertEqual("n3", str(NodeSet("@b", resolver=res)))
+        self.assertEqual(sorted(res.grouplist()), ['a', 'b'])
+
+    def test_mapall_all_nodes_single_call(self):
+        """test @* fallback (list+map) is served by a single mapall call"""
+        source = StaticGroupSource('msc', {
+            'mapall': "a: n[1-2]\nb: n[3-4]\n",
+        })
+        calls = []
+        orig_upcall_read = source._upcall_read
+        def counting_upcall_read(cmdtpl, args=dict()):
+            calls.append(cmdtpl)
+            return orig_upcall_read(cmdtpl, args)
+        source._upcall_read = counting_upcall_read
+        res = GroupResolver(source)
+        self.assertEqual("n[1-4]", str(NodeSet("@*", resolver=res)))
+        self.assertEqual(calls, ['mapall'])
+
+    def test_mapall_parse_error_retry(self):
+        """test that mapall output is not cached on parse error"""
+        source = StaticGroupSource('mr', {
+            'mapall': "broken_no_colon\n",
+        })
+        res = GroupResolver(source)
+        self.assertRaises(GroupSourceQueryFailed, res.group_nodes, 'a')
+        # fixed output must be picked up by the next call, not cached error
+        source._data['mapall'] = "a: n1\n"
+        self.assertEqual("n1", str(NodeSet("@a", resolver=res)))
+
+    def test_mapall_all_still_required(self):
+        """test that 'all' is not derived from mapall"""
+        source = StaticGroupSource('ma', {
+            'mapall': "a: n1\nb: n2\n",
+        })
+        res = GroupResolver(source)
+        self.assertRaises(GroupSourceNoUpcall, res.all_nodes)
+
+    def test_no_upcalls_lazy_error(self):
+        """test UpcallGroupSource without any upcall fails on resolution"""
+        source = UpcallGroupSource('bad')
+        self.assertRaises(GroupSourceNoUpcall, source.resolv_map, 'x')
+        self.assertRaises(GroupSourceNoUpcall, source.resolv_list)
+
+    def test_config_mapall_only(self):
+        """test config with mapall upcall and no map"""
+        f = make_temp_file(dedent("""
+            [Main]
+            default: bulk
+
+            [bulk]
+            mapall: printf 'g1: n[1-3]\\ng2: n[4-5]\\n'
+            """).encode('ascii'))
+        res = GroupResolverConfig(f.name)
+        self.assertEqual("n[1-3]", str(NodeSet("@g1", resolver=res)))
+        self.assertEqual("n[4-5]", str(NodeSet("@g2", resolver=res)))
+        self.assertEqual(sorted(res.grouplist()), ['g1', 'g2'])
+
+    def test_config_mapall_query_failed(self):
+        """test config with failing mapall upcall (not cached, retried)"""
+        data = make_temp_file(b"")
+        f = make_temp_file(dedent("""
+            [Main]
+            default: bulk
+
+            [bulk]
+            mapall: test -s %s && cat %s
+            """ % (data.name, data.name)).encode('ascii'))
+        res = GroupResolverConfig(f.name)
+        # empty data file: mapall upcall exits non-zero
+        self.assertRaises(GroupSourceQueryFailed, res.grouplist)
+        # upcall failure is not cached: fix data file and retry
+        data.write(b"a: n1\n")
+        data.flush()
+        self.assertEqual(['a'], list(res.grouplist()))
+        self.assertEqual("n1", str(NodeSet("@a", resolver=res)))
+
+    def test_config_map_or_mapall_required(self):
+        """test config without map or mapall raises GroupResolverConfigError"""
+        f = make_temp_file(dedent("""
+            [Main]
+            default: nope
+
+            [nope]
+            list: echo foo
+            """).encode('ascii'))
+        res = GroupResolverConfig(f.name)
+        self.assertRaises(GroupResolverConfigError, res.grouplist)
 
 
 class GroupSourceTest(unittest.TestCase):


### PR DESCRIPTION
Group sources backed by Slurm, Ansible inventory, etc. can typically dump every group-to-nodes mapping in a single command, but ClusterShell forced N+1 sub-process invocations (one 'list' followed by one 'map' per group). On large or slow backends this is a meaningful overhead.

This patch introduces an optional 'mapall' upcall whose output is one 'group: nodes' line per group. When defined, ClusterShell runs it once to populate the cache and then serves 'map' and 'list' queries from it. Either 'map' or 'mapall' is required; both may coexist, in which case 'map' acts as a per-group fallback for groups missing from 'mapall'.

API notes:
- `UpcallGroupSource`: `map_upcall` now defaults to `None` (validation is done at config level); `mapall_upcall` is appended at the end of the signature so existing positional callers are unaffected.
- `groups.conf.5` regenerated from `doc/txt/groups.conf.txt`.

Closes #612.