### PR TITLE
Display: fix line buffering on Python 3.6 (#597)

### DIFF
--- a/lib/ClusterShell/CLI/Display.py
+++ b/lib/ClusterShell/CLI/Display.py
@@ -25,6 +25,7 @@ CLI results display class
 from __future__ import print_function
 
 import difflib
+import io
 import sys
 import os
 
@@ -116,19 +117,19 @@ class Display(object):
                 color = True
 
         self._color = color
-        # GH#528 enable line buffering
+        # GH#528/GH#597 enable line buffering (rewrap buffer on Py 3.6)
         self.out = sys.stdout
-        try :
+        self.err = sys.stderr
+        if hasattr(self.out, 'reconfigure'):  # Py 3.7+
             if not self.out.line_buffering:
                 self.out.reconfigure(line_buffering=True)
-        except AttributeError:  # < py3.7
-            pass
-        self.err = sys.stderr
-        try :
             if not self.err.line_buffering:
                 self.err.reconfigure(line_buffering=True)
-        except AttributeError:  # < py3.7
-            pass
+        elif hasattr(self.out, 'buffer'):  # Py 3.6
+            self.out = io.TextIOWrapper(self.out.buffer, encoding=self.out.encoding,
+                                        errors=self.out.errors, line_buffering=True)
+            self.err = io.TextIOWrapper(self.err.buffer, encoding=self.err.encoding,
+                                        errors=self.err.errors, line_buffering=True)
 
         if self._color:
             self.color_stdout_fmt = self.COLOR_STDOUT_FMT

--- a/tests/CLIClushTest.py
+++ b/tests/CLIClushTest.py
@@ -762,6 +762,32 @@ class CLIClushTest_A(unittest.TestCase):
         finally:
             ClusterShell.CLI.Clush.ask_pass = ask_pass_save
 
+    def test_045_pipe_line_buffering(self):
+        """test clush stdout line buffering when piped (GH#597)"""
+        # Remote command emits 3 lines with a sleep between each. With the
+        # fix, lines arrive ~0.5s apart through the pipe. If clush stdout is
+        # block-buffered (the bug), all 3 arrive together at child exit.
+        python_exec = basename(sys.executable or 'python')
+        args = ['-w', HOSTNAME, '--worker=exec', '-q',
+                'for i in A B C; do echo $i; sleep 0.5; done']
+        with Popen([python_exec, '-m', 'ClusterShell.CLI.Clush'] + args,
+                   stdout=PIPE, stderr=PIPE,
+                   universal_newlines=True, bufsize=1) as process:
+            timestamps = []
+            t0 = time.monotonic()
+            for _line in process.stdout:
+                timestamps.append(time.monotonic() - t0)
+            process.wait(timeout=10)
+        self.assertEqual(len(timestamps), 3,
+                         "expected 3 lines, got %d" % len(timestamps))
+        spread = timestamps[-1] - timestamps[0]
+        # Bug signature: spread ~0 (lines released together at clush exit).
+        # Fix signature: spread ~1s. 0.5s threshold = midpoint, equally far
+        # from both signals — generous for CI jitter.
+        self.assertGreater(spread, 0.5,
+                           "lines arrived together (spread=%.3fs); "
+                           "clush stdout looks block-buffered" % spread)
+
 
 class CLIClushTest_B_StdinFailure(unittest.TestCase):
     """Unit test class for testing CLI/Clush.py and stdin failure"""


### PR DESCRIPTION
reconfigure() is Py3.7+; on Py3.6 the silent except left stdout/stderr block-buffered when piped. Re-wrap the underlying buffer with line_buffering enabled at construction time. Init-only cost; write hot path unchanged.

Closes #597