### PR TITLE
Tree: ev_pickup fires only when the command can no longer be rerouted (#594)

### DIFF
--- a/lib/ClusterShell/Propagation.py
+++ b/lib/ClusterShell/Propagation.py
@@ -222,21 +222,34 @@ class PropagationChannel(Channel):
         self._rc = None
         self.logger = logging.getLogger(__name__)
 
-    def send_queued(self, ctl):
+    def _send_ctl(self, ctl, pickup_worker=None, pickup_nodes=None):
+        """Actually push a CTL message on the wire.
+
+        If pickup_worker is set, fires _emit_pickup() on the meta
+        worker for every target node, AFTER the send -- so ev_pickup
+        only fires when the command really left the local process
+        (#594). write()/set_write_eof() don't carry pickup args.
+        """
+        self.send(ctl)
+        if pickup_worker is not None and pickup_nodes is not None:
+            for node in pickup_nodes:
+                pickup_worker._emit_pickup(node)
+
+    def send_queued(self, ctl, pickup_worker=None, pickup_nodes=None):
         """helper used to send a message, using msg queue if needed"""
         if self.setup and not self._sendq:
             # send now if channel is setup and sendq empty
-            self.send(ctl)
+            self._send_ctl(ctl, pickup_worker, pickup_nodes)
         else:
             self.logger.debug("send_queued: %d", len(self._sendq))
-            self._sendq.appendleft(ctl)
+            self._sendq.appendleft((ctl, pickup_worker, pickup_nodes))
 
     def send_dequeue(self):
         """helper used to send one queued message (if any)"""
         if self._sendq:
-            ctl = self._sendq.pop()
+            ctl, pickup_worker, pickup_nodes = self._sendq.pop()
             self.logger.debug("dequeuing sendq: %s", ctl)
-            self.send(ctl)
+            self._send_ctl(ctl, pickup_worker, pickup_nodes)
 
     def start(self):
         """start propagation channel"""
@@ -300,7 +313,9 @@ class PropagationChannel(Channel):
             'remote': remote,
         }
         ctl.data_encode(ctl_data)
-        self.send_queued(ctl)
+        # Pass worker + nodes so _emit_pickup fires only when the CTL
+        # actually leaves the local process (#594).
+        self.send_queued(ctl, pickup_worker=worker, pickup_nodes=nodes)
 
     def write(self, nodes, buf, worker):
         """write buffer through channel to nodes on standard input"""

--- a/lib/ClusterShell/Worker/Tree.py
+++ b/lib/ClusterShell/Worker/Tree.py
@@ -55,6 +55,13 @@ class MetaWorkerEventHandler(EventHandler):
         self.logger.debug("MetaWorkerEventHandler: ev_start")
         self.metaworker._start_count += 1
 
+    def ev_pickup(self, worker, node):
+        """
+        Called for each node a child worker has just picked up.
+        Propagate the event to the meta worker.
+        """
+        self.metaworker._emit_pickup(node)
+
     def ev_read(self, worker, node, sname, msg):
         """
         Called to indicate that a worker has data to read.
@@ -163,6 +170,10 @@ class TreeWorker(DistantWorker):
         self._target_count = 0
         self._has_timeout = False
         self._started = False
+        self._initialized = False
+        self._aborted = False
+        # buffered pickup events queued during _launch() (before ev_start)
+        self._pending_pickups = []
 
         if self.command is None and self.source is None:
             raise ValueError("missing command or source parameter in "
@@ -365,6 +376,7 @@ class TreeWorker(DistantWorker):
         self.logger.debug('_copy_remote: tar cmd: %s', cmd)
 
         pchan = self.task._pchannel(gateway, self)
+        # ev_pickup is fired by PropagationChannel._send_ctl after the send
         pchan.shell(nodes=targets, command=cmd, worker=self, timeout=timeout,
                     stderr=self.stderr, gw_invoke_cmd=self.invoke_gateway,
                     remote=self.remote)
@@ -381,6 +393,7 @@ class TreeWorker(DistantWorker):
         self.gwtargets.setdefault(str(gateway), set()).update(targets)
 
         pchan = self.task._pchannel(gateway, self)
+        # ev_pickup is fired by PropagationChannel._send_ctl after the send
         pchan.shell(nodes=targets, command=cmd, worker=self, timeout=timeout,
                     stderr=self.stderr, gw_invoke_cmd=self.invoke_gateway,
                     remote=self.remote)
@@ -492,16 +505,45 @@ class TreeWorker(DistantWorker):
         self.logger.debug("_on_routing_event %s", arg)
         self.eh._ev_routing(self, arg)
 
+    def _emit_pickup(self, node):
+        """Fire ev_pickup for a node, or queue it until ev_start fires.
+
+        Direct child workers route pickups through MetaWorkerEventHandler.
+        Gateway-routed targets route pickups through PropagationChannel
+        ._send_ctl, after the CTL is actually written on the wire.
+        Skipped when the worker has been aborted.
+
+        The 1:1 invariant between ev_pickup and ev_hup per node is held
+        structurally by the callers: Worker._on_start fires ev_pickup
+        at most once per child node-key (direct path); _send_ctl runs
+        at most once per actual channel.send (gateway path), and reroute
+        only happens when the previous CTL was never sent -- so a
+        rerouted target has not yet been emitted. See
+        test_tree_run_gw2f1_reroute and
+        test_tree_run_gw2f1_no_double_pickup_under_reroute.
+        """
+        if self.eh is None or self._aborted:
+            return
+        if self._initialized:
+            _eh_sigspec_invoke_compat(self.eh.ev_pickup, 2, self, node)
+        else:
+            # ev_start has not fired yet; defer to preserve ordering
+            self._pending_pickups.append(node)
+
     def _check_ini(self):
         self.logger.debug("TreeWorker: _check_ini (%d, %d)", self._start_count,
                           self._child_count)
-        if self.eh is not None and self._start_count >= self._child_count:
+        if (self.eh is not None and not self._initialized
+                and self._start_count >= self._child_count):
             # this part is called once
+            self._initialized = True
             self.eh.ev_start(self)
-            # Blindly generate pickup events: this could maybe be improved, for
-            # example, generated only when commands are sent to the gateways
-            # or for direct targets, using MetaWorkerEventHandler.
-            for node in self.nodes:
+            # Flush pickup events buffered during _launch(). If ev_start
+            # aborted the worker, no pickups are emitted (#594).
+            pending, self._pending_pickups = self._pending_pickups, []
+            for node in pending:
+                if self._aborted:
+                    break
                 _eh_sigspec_invoke_compat(self.eh.ev_pickup, 2, self, node)
 
     def _check_fini(self, gateway=None):
@@ -588,6 +630,9 @@ class TreeWorker(DistantWorker):
     def abort(self):
         """Abort processing any action by this worker."""
         self.logger.debug("abort %s" % self)
+        # Stop pending and future pickup events (#594)
+        self._aborted = True
+        self._pending_pickups = []
         for worker in self.workers:
             worker.abort()
         for gateway in self.gwtargets.copy():

--- a/tests/TreeWorkerTest.py
+++ b/tests/TreeWorkerTest.py
@@ -114,6 +114,11 @@ class TRoutingEventHandler(TEventHandler):
     def __init__(self):
         TEventHandler.__init__(self)
         self.routing_events = []
+        self.pickup_nodes = []
+
+    def ev_pickup(self, worker, node):
+        TEventHandler.ev_pickup(self, worker, node)
+        self.pickup_nodes.append(str(node))
 
     def _ev_routing(self, worker, arg):
         self.routing_events.append((worker, arg))
@@ -614,10 +619,38 @@ class TreeWorkerTest(TreeWorkerTestBase):
         teh = TEventAbortOnStartHandler(self)
         self.task.run('echo Lorem Ipsum', nodes=NODE_DISTANT, handler=teh)
         self.assertEqual(teh.ev_start_cnt, 1)
-        #self.assertEqual(teh.ev_pickup_cnt, 0) # XXX to be improved
+        self.assertEqual(teh.ev_pickup_cnt, 0) # #594: aborted on start
         self.assertEqual(teh.ev_read_cnt, 0)
         self.assertEqual(teh.ev_written_cnt, 0)
         self.assertEqual(teh.ev_hup_cnt, 1)
+        self.assertEqual(teh.ev_timedout_cnt, 0)
+        self.assertEqual(teh.ev_close_cnt, 1)
+        self.assertEqual(teh.last_read, None)
+
+    def test_tree_run_abort_on_start_multi(self):
+        """test tree run abort on ev_start, multiple nodes"""
+        # #594: exercises clearance of buffered pickups for >1 node
+        class TEventAbortOnStartHandler(TEventHandler):
+            def __init__(self, testcase):
+                TEventHandler.__init__(self)
+                self.testcase = testcase
+
+            def ev_start(self, worker):
+                TEventHandler.ev_start(self, worker)
+                worker.abort()
+
+            def ev_hup(self, worker, node, rc):
+                TEventHandler.ev_hup(self, worker, node, rc)
+                self.testcase.assertEqual(rc, os.EX_PROTOCOL)
+
+        teh = TEventAbortOnStartHandler(self)
+        self.task.run('echo Lorem Ipsum', nodes=NODE_DISTANT2, handler=teh)
+        target_cnt = len(NodeSet(NODE_DISTANT2))
+        self.assertEqual(teh.ev_start_cnt, 1)
+        self.assertEqual(teh.ev_pickup_cnt, 0)
+        self.assertEqual(teh.ev_read_cnt, 0)
+        self.assertEqual(teh.ev_written_cnt, 0)
+        self.assertEqual(teh.ev_hup_cnt, target_cnt)
         self.assertEqual(teh.ev_timedout_cnt, 0)
         self.assertEqual(teh.ev_close_cnt, 1)
         self.assertEqual(teh.last_read, None)
@@ -831,6 +864,37 @@ class TreeWorkerGW2Test(TreeWorkerTestBase):
         self.assertEqual(teh.ev_timedout_cnt, 2)  # command timed out
         self.assertEqual(teh.ev_close_cnt, 2)
 
+    def test_tree_run_gw2_abort_on_pickup_mid_flush(self):
+        """test tree run abort on ev_pickup during _check_ini flush (#594)"""
+        class TEventAbortOnPickupHandler(TEventHandler):
+            """Test Event Abort On Pickup Handler"""
+
+            def __init__(self, testcase):
+                TEventHandler.__init__(self)
+                self.testcase = testcase
+
+            def ev_pickup(self, worker, node):
+                TEventHandler.ev_pickup(self, worker, node)
+                worker.abort()
+
+            def ev_hup(self, worker, node, rc):
+                TEventHandler.ev_hup(self, worker, node, rc)
+                self.testcase.assertEqual(rc, os.EX_PROTOCOL)
+
+        teh = TEventAbortOnPickupHandler(self)
+        self.task.run('echo Lorem Ipsum', nodes=NODE_DISTANT2, handler=teh)
+        target_cnt = len(NodeSet(NODE_DISTANT2))
+        self.assertEqual(teh.ev_start_cnt, 1)
+        # First pickup fires and aborts; the inner break in _check_ini
+        # stops the second buffered pickup from firing.
+        self.assertEqual(teh.ev_pickup_cnt, 1)
+        self.assertEqual(teh.ev_read_cnt, 0)
+        self.assertEqual(teh.ev_written_cnt, 0)
+        self.assertEqual(teh.ev_hup_cnt, target_cnt)
+        self.assertEqual(teh.ev_timedout_cnt, 0)
+        self.assertEqual(teh.ev_close_cnt, 1)
+        self.assertEqual(teh.last_read, None)
+
     def test_tree_run_gw2_write_distant(self):
         """test tree run with write(), 2 gateways, distant target"""
         self._tree_run_write(NODE_DISTANT)
@@ -929,6 +993,14 @@ class TreeWorkerGW2F1FTest(TreeWorkerTestBase):
         # event handler checks
         self.assertEqual(teh.ev_start_cnt, 1)
         self.assertEqual(teh.ev_pickup_cnt, 2)
+        # #594: each node fires ev_pickup EXACTLY ONCE even after reroute.
+        # This holds structurally: PropagationChannel._send_ctl runs at
+        # most once per actual channel.send, and a CTL queued behind a
+        # never-acked CFG message is GC'd before any send -- so a
+        # rerouted target's first _emit_pickup is the only one. The list
+        # comparison (not a set) below catches accidental double-fires.
+        self.assertEqual(sorted(teh.pickup_nodes),
+                         sorted(str(n) for n in NodeSet(NODE_DISTANT2)))
         # read_cnt += 1 for gateway error on stderr (so currently not fully
         # transparent to the user)
         self.assertEqual(teh.ev_read_cnt, 3)
@@ -937,3 +1009,76 @@ class TreeWorkerGW2F1FTest(TreeWorkerTestBase):
         self.assertEqual(teh.ev_timedout_cnt, 0)
         self.assertEqual(teh.ev_close_cnt, 1)
         self.assertEqual(teh.last_read, b'Lorem Ipsum')
+
+    def test_tree_run_gw2f1_no_double_pickup_under_reroute(self):
+        """test #594 invariant: rerouted target fires ev_pickup at most once
+
+        Companion to test_tree_run_gw2f1_reroute focused solely on the
+        no-double-fire invariant. With pickup emission centralized in
+        PropagationChannel._send_ctl (runs once per actual channel.send)
+        and Worker._on_start (fires once per child node-key), the same
+        node cannot see ev_pickup twice -- even when its initial gateway
+        fails before CFG-ACK and the target is rerouted to a working
+        gateway. If a future refactor reintroduces eager pickup emission
+        from any pre-send site, this test fails immediately.
+        """
+        teh = TRoutingEventHandler()
+        self.task.run('echo Lorem Ipsum', nodes=NODE_DISTANT2, handler=teh)
+
+        # Exactly one reroute happened (the failed gateway).
+        self.assertEqual(len(teh.routing_events), 1)
+
+        # pickup_nodes is a list (one entry per ev_pickup CALL, not a
+        # deduped set). It must have no duplicates.
+        self.assertEqual(len(teh.pickup_nodes), len(set(teh.pickup_nodes)),
+                         "ev_pickup fired more than once for some node: %s"
+                         % teh.pickup_nodes)
+        self.assertEqual(set(teh.pickup_nodes),
+                         set(str(n) for n in NodeSet(NODE_DISTANT2)))
+
+    def test_tree_run_gw2f1_pickup_after_reroute(self):
+        """test ev_pickup for a rerouted target fires after _ev_routing (#594)"""
+        class TOrderedRoutingEventHandler(TRoutingEventHandler):
+            """Record the absolute order of pickup and routing events."""
+
+            def __init__(self):
+                TRoutingEventHandler.__init__(self)
+                self.event_order = []  # ('pickup', node) | ('routing', arg)
+
+            def ev_pickup(self, worker, node):
+                TRoutingEventHandler.ev_pickup(self, worker, node)
+                self.event_order.append(('pickup', str(node)))
+
+            def _ev_routing(self, worker, arg):
+                TRoutingEventHandler._ev_routing(self, worker, arg)
+                self.event_order.append(('routing', arg))
+
+        teh = TOrderedRoutingEventHandler()
+        self.task.run('echo Lorem Ipsum', nodes=NODE_DISTANT2, handler=teh)
+
+        # one reroute event for the down gateway
+        self.assertEqual(len(teh.routing_events), 1)
+        _, routing_arg = teh.routing_events[0]
+        rerouted = NodeSet(routing_arg['targets'])
+
+        # locate the routing event in the absolute event timeline
+        routing_idx = next(i for i, (name, _) in enumerate(teh.event_order)
+                           if name == 'routing')
+
+        # every rerouted target's ev_pickup must come AFTER the routing event:
+        # _emit_pickup now fires from PropagationChannel only when the CTL
+        # actually leaves the local process, so a target whose initial
+        # gateway is unreachable cannot be 'picked up' until the reroute
+        # places its send on a working channel.
+        for target in rerouted:
+            tgt = str(target)
+            pickup_idx = next((i for i, (name, payload)
+                              in enumerate(teh.event_order)
+                              if name == 'pickup' and payload == tgt), None)
+            self.assertIsNotNone(
+                pickup_idx,
+                "missing ev_pickup for rerouted target %s" % tgt)
+            self.assertGreater(
+                pickup_idx, routing_idx,
+                "ev_pickup for rerouted target %s fired before _ev_routing"
+                % tgt)


### PR DESCRIPTION
Previously ev_pickup fired from _check_ini for every node right after ev_start, regardless of whether the command had actually been sent (with an unreachable gateway, the CTL may sit in _sendq forever and the target is eventually rerouted to a working gateway) or whether the worker had been aborted. Reroutes also double-fired pickup for
the same target.

Move emission to the actual send sites:
- direct path: MetaWorkerEventHandler.ev_pickup hook (Worker._on_start  fires once per child node-key)
- gateway path: new PropagationChannel._send_ctl helper invoked once  per actual channel.send. By construction _send_ctl runs only after the channel has reached setup=True (either via the immediate-send path which requires it, or via send_dequeue after CFG-ACK), and reroute via _relaunch is gated on setup=False -- so a target whose ev_pickup has fired cannot be rerouted.

write() and set_write_eof() keep the no-pickup path: subsequent traffic on an already-picked-up node must not double-fire.

_emit_pickup gates on _aborted and buffers events before ev_start. The 1:1 ev_pickup-per-node invariant is held structurally by the call sites. Reroute is signaled only by _ev_routing.

Closes #594