### PR TITLE
HPSF onboarding: charter, DCO, governance, README, acknowledgments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to ClusterShell
+
+Contributions are welcome via [GitHub pull requests](https://github.com/clustershell/clustershell/pulls).
+For bug reports and feature requests, please open a [GitHub issue](https://github.com/clustershell/clustershell/issues).
+
+For project roles, decision-making, and maintainer information, see [GOVERNANCE.md](GOVERNANCE.md).
+This project also adheres to a [Technical Charter](https://clustershell.readthedocs.io/en/latest/CHARTER.html), which defines its governance model, decision-making process, and contribution requirements.
+
+## Developer Certificate of Origin (DCO)
+
+All commits must include a `Signed-off-by` line certifying that you have the
+right to submit the contribution under the project's license, per the
+[Developer Certificate of Origin](https://developercertificate.org/). If you
+are contributing on behalf of your employer, your sign-off attests that your
+employer has authorized the contribution under the DCO.
+
+Add it with the `-s` flag:
+
+```
+git commit -s -m "Your commit message"
+```
+
+This produces a line like:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+The name and email must match your Git configuration (`git config user.name`
+and `git config user.email`). Pull requests with missing sign-offs will be
+blocked by an automated check.
+
+To fix a missing sign-off on the last commit:
+
+```
+git commit --amend -s
+```
+
+To sign off multiple commits at once:
+
+```
+git rebase HEAD~N --signoff   # sign off the last N commits
+```

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,6 +2,12 @@
 
 This document describes the governance model of the ClusterShell project.
 
+ClusterShell is a project of [Linux Foundation Europe](https://linuxfoundation.eu/)
+and an [HPSF Established](https://hpsf.io) project. The formal technical
+governance is set out in the [Technical Charter](https://clustershell.readthedocs.io/en/latest/CHARTER.html).
+This document provides the operational details of how that charter is applied
+day-to-day.
+
 ClusterShell is maintained by a small group of maintainers. The project aims to remain lightweight and responsive while ensuring continuity if an individual maintainer becomes unavailable.
 
 ## Roles

--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 ClusterShell Python Library and Tools
 =====================================
 
-ClusterShell is an event-driven open source Python library, designed to run
+[![HPSF Established](https://raw.githubusercontent.com/hpsfoundation/tac/main/badges/HPSF_Project_Badge_Established.png)](https://hpsf.io)
+
+This project adheres to a [Technical Charter](https://clustershell.readthedocs.io/en/latest/CHARTER.html), which defines its governance model, decision-making process, and long-term vision.
+
+ClusterShell is an event-driven open source Python library designed to run
 local or distant commands in parallel on server farms or on large Linux
-clusters. It will take care of common issues encountered on HPC clusters, such
-as operating on groups of nodes, running distributed commands using optimized
-execution algorithms, as well as gathering results and merging identical
-outputs, or retrieving return codes. ClusterShell takes advantage of existing
-remote shell facilities already installed on your systems, like SSH.
+clusters. It is an [HPSF Established](https://hpsf.io) project under
+[LF Europe](https://linuxfoundation.eu/) stewardship.
+
+ClusterShell handles typical HPC cluster administration tasks: operating on
+groups of nodes, executing distributed commands with optimized algorithms,
+gathering and merging output, and collecting return codes. It leverages remote
+shell facilities already present on your systems, such as SSH.
 
 ClusterShell's primary goal is to improve the administration of high-
 performance clusters by providing a lightweight but scalable Python API for
@@ -84,31 +90,21 @@ linux[4-6] 2.6.32-71.el6.x86_64
 Links
 -----
 
-Web site:
-
-    http://cea-hpc.github.com/clustershell/
-
 Online documentation:
 
     https://clustershell.readthedocs.io/
 
 Github source repository:
 
-    https://github.com/cea-hpc/clustershell
-
-Github Wiki:
-
-    https://github.com/cea-hpc/clustershell/wiki
+    https://github.com/clustershell/clustershell
 
 Github Issue tracking system:
 
-    https://github.com/cea-hpc/clustershell/issues
+    https://github.com/clustershell/clustershell/issues
 
 Python Package Index (PyPI) links:
 
     https://pypi.org/project/ClusterShell/
-
-    http://pypi.python.org/pypi/ClusterShell
 
 ClusterShell was born along with Shine, a scalable Lustre FS admin tool:
 
@@ -119,7 +115,16 @@ Core developers/reviewers
 
 * Stephane Thiell
 * Aurelien Degremont
-* Henri Doreau
 * Dominique Martinet
 
-CEA/DAM 2010, 2011, 2012, 2013, 2014, 2015 - http://www-hpc.cea.fr
+Acknowledgments
+---------------
+
+We would like to express our gratitude to [CEA](https://www.cea.fr/english)
+for the resources and funding provided to the project over the years.
+
+We would also like to thank [Stanford University](https://srcc.stanford.edu)
+(SRC) for their long-term support and resources provided to the project.
+
+See the full [Acknowledgments](https://clustershell.readthedocs.io/en/latest/acknowledgments.html)
+page for more details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ Security updates will be made available as patch (x.y.1, x.y.2, etc.) releases.
 
 You can report a vulnerability using GitHub's private reporting feature:
 
-1. Go to [github.com/cea-hpc/clustershell/security](https://github.com/cea-hpc/clustershell/security).
+1. Go to [github.com/clustershell/clustershell/security](https://github.com/clustershell/clustershell/security).
 2. Click "Report a vulnerability" in the upper right corner of that page.
 3. Fill out the form and submit your draft security advisory.
 

--- a/doc/sphinx/CHARTER.rst
+++ b/doc/sphinx/CHARTER.rst
@@ -1,0 +1,233 @@
+.. _CHARTER:
+
+ClusterShell Technical Charter
+===============================
+
+**Technical Charter (the "Charter") for ClusterShell.**
+
+**Adopted May 15, 2026**
+
+This Charter sets forth the responsibilities and procedures for technical
+contribution to, and oversight of, the ClusterShell open source project (the
+"Project"), which has been established as a project of Linux Foundation
+Europe, a Belgian private stichting headquartered at Kunstlaan 56, Brussels
+("LF Europe"). All contributors (including maintainers, and other technical
+positions) and other participants in the Project (collectively,
+"Collaborators") must comply with the terms of this Charter.
+
+1. **Mission and Scope of the Project**
+
+   a. The mission of the Project is to enable scalable parallel execution and
+      powerful node group manipulation with the goal of simplifying the
+      administration and operation of large high-performance computing
+      clusters.
+
+   b. The scope of the Project includes collaborative development under the
+      Project License (as defined herein) supporting the mission, including
+      documentation, testing, integration and the creation of other artifacts
+      that aid the development, deployment, operation or adoption of the open
+      source project.
+
+2. **Technical Steering Committee**
+
+   a. The Technical Steering Committee (the "TSC") will be responsible for
+      all technical oversight of the open source Project.
+
+   b. The TSC voting members are initially the Project's Maintainers. At the
+      inception of the project, the Maintainers of the Project will be as set
+      forth within the "GOVERNANCE" file within the Project's code repository.
+      The TSC may choose an alternative approach for determining the voting
+      members of the TSC, and any such alternative approach will be documented
+      in the GOVERNANCE file. Any meetings of the Technical Steering Committee
+      are intended to be open to the public, and can be conducted
+      electronically, via teleconference, or in person.
+
+   c. TSC projects generally will involve Contributors and Maintainers. The
+      TSC may adopt or modify roles so long as the roles are documented in the
+      GOVERNANCE file. Unless otherwise documented:
+
+      i.   Contributors include anyone in the technical community that
+           contributes code, documentation, or other technical artifacts to
+           the Project;
+      ii.  Maintainers are Contributors who have earned the ability to modify
+           ("commit") source code, documentation or other technical artifacts
+           in a project's repository; and
+      iii. A Contributor may become a Maintainer by a majority approval of the
+           TSC. A Maintainer may be removed by a majority approval of the TSC.
+
+   d. Participation in the Project through becoming a Contributor and
+      Maintainer is open to anyone so long as they abide by the terms of this
+      Charter.
+
+   e. The TSC may (1) establish work flow procedures for the submission,
+      approval, and closure/archiving of projects, (2) set requirements for
+      the promotion of Contributors to Maintainer status, as applicable, and
+      (3) amend, adjust, refine and/or eliminate the roles of Contributors,
+      and Maintainers, and create new roles, and publicly document any TSC roles,
+      as it sees fit.
+
+   f. The TSC may elect a TSC Chair, who will preside over meetings of the TSC
+      and will serve until their resignation or replacement by the TSC. The
+      TSC Chair, or any other TSC member so designated by the TSC, will serve
+      as the primary communication contact between the Project and High
+      Performance Software Foundation (HPSF), a directed fund of The Linux
+      Foundation.
+
+   g. Responsibilities: The TSC will be responsible for all aspects of
+      oversight relating to the Project, which may include:
+
+      i.    coordinating the technical direction of the Project;
+      ii.   approving project or system proposals (including, but not limited
+            to, incubation, deprecation, and changes to a sub-project's
+            scope);
+      iii.  organizing sub-projects and removing sub-projects;
+      iv.   creating sub-committees or working groups to focus on cross-project
+            technical issues and requirements;
+      v.    appointing representatives to work with other open source or open
+            standards communities;
+      vi.   establishing community norms, workflows, issuing releases, and
+            security issue reporting policies;
+      vii.  approving and implementing policies and processes for contributing
+            (to be published in the CONTRIBUTING file) and coordinating with
+            LF Europe to resolve matters or concerns that may arise as set
+            forth in Section 7 of this Charter;
+      viii. discussions, seeking consensus, and where necessary, voting on
+            technical matters relating to the code base that affect multiple
+            projects; and
+      ix.   coordinating any marketing, events, or communications regarding
+            the Project.
+
+3. **TSC Voting**
+
+   a. While the Project aims to operate as a consensus-based community, if any
+      TSC decision requires a vote to move the Project forward, the voting
+      members of the TSC will vote on a one vote per voting member basis.
+
+   b. Quorum for TSC meetings requires at least fifty percent of all voting
+      members of the TSC to be present. The TSC may continue to meet if quorum
+      is not met but will be prevented from making any decisions at the
+      meeting.
+
+   c. Except as provided in Section 7.c. and 8.a, decisions by vote at a
+      meeting require a majority vote of those in attendance, provided quorum
+      is met. Decisions made by electronic vote without a meeting require a
+      majority vote of all voting members of the TSC.
+
+   d. In the event a vote cannot be resolved by the TSC, any voting member of
+      the TSC may refer the matter to LF Europe for assistance in reaching a
+      resolution.
+
+4. **Compliance with Policies**
+
+   a. Contributors will comply with the policies of LF Europe as may be
+      adopted and amended by LF Europe, including, without limitation the
+      policies listed at https://linuxfoundation.eu/policies/.
+
+   b. The TSC may adopt a code of conduct ("CoC") for the Project, which is
+      subject to approval by LF Europe. In the event that a Project-specific
+      CoC has not been approved, the LF Europe Code of Conduct listed at
+      https://linuxfoundation.eu/policies/ will apply for all Collaborators in
+      the Project.
+
+   c. When amending or adopting any policy applicable to the Project, LF
+      Europe will publish such policy, as to be amended or adopted, on its web
+      site at least 30 days prior to such policy taking effect; provided,
+      however, that in the case of any amendment of the Trademark Policy or
+      Terms of Use of LF Europe, any such amendment is effective upon
+      publication on LF Project's web site.
+
+   d. All Collaborators must allow open participation from any individual or
+      organization meeting the requirements for contributing under this Charter
+      and any policies adopted for all Collaborators by the TSC, regardless of
+      competitive interests. Put another way, the Project community must not
+      seek to exclude any participant based on any criteria, requirement, or
+      reason other than those that are reasonable and applied on a
+      non-discriminatory basis to all Collaborators in the Project community.
+
+   e. The Project will operate in a transparent, open, collaborative, and
+      ethical manner at all times. The output of all Project discussions,
+      proposals, timelines, decisions, and status should be made open and
+      easily visible to all. Any potential violations of this requirement
+      should be reported immediately to LF Europe.
+
+5. **Community Assets**
+
+   a. LF Europe will hold title to all trade or service marks used by the
+      Project ("Project Trademarks"), whether based on common law or registered
+      rights. Project Trademarks will be transferred and assigned to LF Europe
+      to hold on behalf of the Project. Any use of any Project Trademarks by
+      Collaborators in the Project will be in accordance with the license from
+      LF Europe and inure to the benefit of LF Europe.
+
+   b. The Project will, as permitted and in accordance with such license from
+      LF Europe, develop and own all Project GitHub and social media accounts,
+      and domain name registrations created by the Project community.
+
+   c. Under no circumstances will LF Europe be expected or required to
+      undertake any action on behalf of the Project that is inconsistent with
+      the tax-exempt status or purpose, as applicable, of LF Europe.
+
+6. **General Rules and Operations**
+
+   The Project will:
+
+   a. engage in the work of the Project in a professional manner consistent
+      with maintaining a cohesive community, while also maintaining the
+      goodwill and esteem of LF Europe and other partner organizations in the
+      open source community; and
+
+   b. respect the rights of all trademark owners, including any branding and
+      trademark usage guidelines.
+
+7. **Intellectual Property Policy**
+
+   a. Collaborators acknowledge that the copyright in all new contributions
+      will be retained by the copyright holder as independent works of
+      authorship and that no contributor or copyright holder will be required
+      to assign copyrights to the Project.
+
+   b. Except as described in Section 7.c., all contributions to the Project
+      are subject to the following:
+
+      i.   All new inbound code contributions to the Project must be made
+           using GNU Lesser General Public License, version 2.1 or later
+           (LGPL-2.1-or-later), available at
+           https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html (the
+           "Project License").
+
+      ii.  All new inbound code contributions must also be accompanied by a
+           Developer Certificate of Origin
+           (http://developercertificate.org) sign-off in the source code
+           system that is submitted through a TSC-approved contribution
+           process which will bind the authorized contributor and, if not
+           self-employed, their employer to the applicable license.
+
+      iii. All outbound code will be made available under the Project License.
+
+      iv.  Documentation will be received and made available by the Project
+           under the Creative Commons Attribution 4.0 International License
+           (available at http://creativecommons.org/licenses/by/4.0/).
+
+      v.   The Project may seek to integrate and contribute back to other open
+           source projects ("Upstream Projects"). In such cases, the Project
+           will conform to all license requirements of the Upstream Projects,
+           including dependencies, leveraged by the Project. Upstream Project
+           code contributions not stored within the Project's main code
+           repository will comply with the contribution process and license
+           terms for the applicable Upstream Project.
+
+   c. The TSC may approve the use of an alternative license or licenses for
+      inbound or outbound contributions on an exception basis. To request an
+      exception, please describe the contribution, the alternative open source
+      license(s), and the justification for using an alternative open source
+      license for the Project. License exceptions must be approved by a
+      two-thirds vote of the entire TSC.
+
+   d. Contributed files should contain license information, such as SPDX short
+      form identifiers, indicating the open source license or licenses
+      pertaining to the file.
+
+8. **Amendments**
+
+   This charter may be amended by a two-thirds vote of the entire TSC and is
+   subject to approval by LF Europe.

--- a/doc/sphinx/acknowledgments.rst
+++ b/doc/sphinx/acknowledgments.rst
@@ -1,0 +1,22 @@
+.. _acknowledgments:
+
+Acknowledgments
+===============
+
+We would like to express our gratitude to `CEA`_ for the resources and funding
+provided to the project over the years.
+
+We would also like to thank `Stanford University`_ (SRC) for their long-term
+support and resources provided to the project.
+
+We acknowledge all the contributors and users of the ClusterShell community who
+participate in the quality of the project with valuable feedback and code
+improvements.
+
+The following people have made foundational contributions to ClusterShell and
+ClusterShell would not be what it is without their work:
+
+* Henri Doreau
+
+.. _CEA: https://www.cea.fr/english
+.. _Stanford University: https://srcc.stanford.edu

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -14,6 +14,8 @@ Contents:
    guide/index
    api/index
    further
+   CHARTER
+   acknowledgments
 
 
 Indices and tables


### PR DESCRIPTION
- Add doc/sphinx/CHARTER.rst: LF Europe technical charter adopted May 15, 2026, published via ReadTheDocs per HPSF and LF requirements
- Add doc/sphinx/acknowledgments.rst: acknowledge CEA and Stanford University for their long-term support; recognize notable past contributor Henri Doreau
- Update doc/sphinx/index.rst: add CHARTER and acknowledgments to toctree
- Add CONTRIBUTING.md: minimal guide with DCO sign-off instructions (enforced via LF DCO GitHub App on pull requests)
- Update GOVERNANCE.md: reference Technical Charter and LF Europe stewardship
- Update README.md: add HPSF Established badge, charter link, acknowledgments section, fix stale cea-hpc URLs, remove dead website link
- Update SECURITY.md: fix vulnerability reporting URL (cea-hpc -> clustershell)

Note: DCO enforcement requires installing the LF DCO GitHub App (https://github.com/apps/dco) on clustershell/clustershell after this PR lands, then marking the DCO check required in branch protection for master.