### PR TITLE
completion: add -b/-B and clush's other no-arg options

### DIFF
--- a/bash_completion.d/clush
+++ b/bash_completion.d/clush
@@ -64,7 +64,7 @@ _clush()
 		-w|-g|--group) target_set=1; skip=any;;
 		# no-arg options
 		--version|-h|--help|-n|--nostdin|-a|--all|-q|--quiet|\
-		-v|--verbose|-d|--debug) ;;
+		-b|-B|-v|--verbose|-d|--debug) ;;
 		# get source separately...
 		--groupsource=*) groupsource="${word#*=}";;
 		-s|--groupsource) skip=groupsource;;

--- a/bash_completion.d/clush
+++ b/bash_completion.d/clush
@@ -64,7 +64,8 @@ _clush()
 		-w|-g|--group) target_set=1; skip=any;;
 		# no-arg options
 		--version|-h|--help|-n|--nostdin|-a|--all|-q|--quiet|\
-		-b|-B|-v|--verbose|-d|--debug) ;;
+		-b|-B|--dshbak|-G|--groupbase|-L|-N|-P|--progress|\
+		-r|--regroup|-S|--maxrc|--diff|-p|-v|--verbose|-d|--debug) ;;
 		# get source separately...
 		--groupsource=*) groupsource="${word#*=}";;
 		-s|--groupsource) skip=groupsource;;
@@ -128,7 +129,8 @@ _clush()
 		;;
 	# no-arg options
 	--version|-h|--help|-n|--nostdin|-a|--all|-q|--quiet|\
-	-v|--verbose|-d|--debug|-c|--copy|--rcopy) ;;
+	-b|-B|--dshbak|-G|--groupbase|-L|-N|-P|--progress|\
+	-r|--regroup|-S|--maxrc|--diff|-p|-v|--verbose|-d|--debug|-c|--copy|--rcopy) ;;
 	# any other option: ignore next word (likely argument)
 	-*)
 		return;;


### PR DESCRIPTION
Supersedes #598 by @OleHolmNielsen, rebased onto current master.

`-b`/`-B` and clush's other no-argument options weren't listed in the
bash-completion no-arg cases, so they fell through to the generic
`-*) skip=any` case and the parser consumed the following word as their
argument — e.g. `clush -b -w node01 <TAB>` (likewise `-G`, `-S`,
`--dshbak`, …) stopped completing the command.

- **Commit 1** (@OleHolmNielsen, from #598): add `-b`/`-B` to the no-arg
  list in the word-parsing loop.
- **Commit 2**: complete both no-arg lists (the word-parsing loop and the
  `case "$prev"` block) with all of clush's remaining `store_true`
  options — `--dshbak`, `-G`/`--groupbase`, `-L`, `-N`, `-P`/`--progress`,
  `-r`/`--regroup`, `-S`/`--maxrc`, `--diff`, `-p` — plus `-b`/`-B` parity.
  Completing the list per @martinetd's suggestion on #598.

The full no-arg set was verified against clush's actual option parser
(`takes_value() == False`); `bash -n` is clean.

Note: combined short flags (e.g. `-bg`) are a separate, deeper issue
(per @martinetd's other comment) and intentionally out of scope here.

cc @martinetd
