### PR TITLE
completion: fix cluset's no-arg option lists

### DIFF
--- a/bash_completion.d/cluset
+++ b/bash_completion.d/cluset
@@ -25,8 +25,9 @@ _cluset()
 		"") ;;
 		--) return;;
 		# no-arg options
-		--version|-h|--help|-n|--nostdin|-a|--all|-q|--quiet|\
-		-v|--verbose|-d|--debug) ;;
+		--version|-h|--help|-l|--list|-L|--list-all|-r|--regroup|\
+		--list-sources|--groupsources|-d|--debug|-q|--quiet|\
+		-R|--rangeset|-G|--groupbase|--contiguous|-a|--all|--completion) ;;
 		# get source separately...
 		--groupsource=*) groupsource="${word#*=}";;
 		-s|--groupsource) skip=groupsource;;
@@ -63,7 +64,7 @@ _cluset()
 	# no-arg options
 	--version|-h|--help|-l|--list|-L|--list-all|-r|--regroup|\
 	--list-sources|--groupsources|-d|--debug|-q|--quiet|\
-	-R|--rangeset|-G|--groupbase|--contiguous) ;;
+	-R|--rangeset|-G|--groupbase|--contiguous|-a|--all|--completion) ;;
 	# any other option: just ignore.
 	-*)
 		return;;


### PR DESCRIPTION
Sibling of #619 for cluset: the no-arg option lists were incomplete (and
carried -n/-v from clush), so the parser consumed the word following a
no-arg option and completion stopped, e.g. `cluset -G -e @<TAB>`.

-c/-e/-f intentionally stay out of the word-parsing loop so the nodeset
that follows them is still skipped.