### PR TITLE
conf: add mapall upcall to xCAT group bindings

### DIFF
--- a/conf/groups.conf.d/xcat.conf.example
+++ b/conf/groups.conf.d/xcat.conf.example
@@ -10,6 +10,9 @@
 # list the nodes in the specified node group
 map: lsdef -s -t node "$GROUP" | cut -d' ' -f1
 
+# get all group-to-nodes mappings in one call
+mapall: lsdef -t group -i members | awk '/^Object name: /{g=$3; next} sub(/^ *members=/,""){if (g != "" && g !~ /:/) print g": "$0}'
+
 # list all the nodes defined in the xCAT tables
 all: lsdef -s -t node | cut -d' ' -f1
 

--- a/doc/sphinx/config.rst
+++ b/doc/sphinx/config.rst
@@ -685,7 +685,10 @@ The section **xcat** defines a group source based on xCAT static node groups::
 
     # list the nodes in the specified node group
     map: lsdef -s -t node $GROUP | cut -d' ' -f1
-    
+
+    # get all group-to-nodes mappings in one call
+    mapall: lsdef -t group -i members | awk '/^Object name: /{g=$3; next} sub(/^ *members=/,""){if (g != "" && g !~ /:/) print g": "$0}'
+
     # list all the nodes defined in the xCAT tables
     all: lsdef -s -t node | cut -d' ' -f1
     


### PR DESCRIPTION
Adopt the new `mapall` upcall in the xCAT example group bindings: one `lsdef -t group -i members` call replaces one `lsdef` call per group, for both static and dynamic groups. Group names containing `:` are skipped and remain resolvable through `map`.

`doc/sphinx/config.rst` updated to match.