### PR TITLE
Gateway: fix Python 2 syntax error in RoutingMessage call

### DIFF
--- a/lib/ClusterShell/Gateway.py
+++ b/lib/ClusterShell/Gateway.py
@@ -154,7 +154,7 @@ class TreeWorkerResponder(EventHandler):
         updated one of its route path.
         """
         self.logger.debug("TreeWorkerResponder: ev_routing arg=%s", arg)
-        self.gwchan.send(RoutingMessage(**arg, srcid=self.srcwkr))
+        self.gwchan.send(RoutingMessage(srcid=self.srcwkr, **arg))
 
 
 class GatewayChannel(Channel):


### PR DESCRIPTION
Keyword arguments after `**kwargs` unpacking are Python 3.5+-only syntax (PEP 448), a `SyntaxError` on Python 2.7 that makes `import ClusterShell.Gateway` fail entirely (tree mode unusable, el7 byte-compilation breaks). Reordering the kwargs is strictly equivalent — `RoutingMessage` takes only defaulted keyword arguments.

No functional change. Introduced by b518c95 (#594 work), unreleased — 1.9.3 is not affected.

Verified: `py_compile` passes on Python 2.7.5 (CentOS 7); all tree worker/gateway tests pass on Python 3.