### PR TITLE
tests: skip pdsh tests when pdsh is not installed

### DIFF
--- a/tests/CLIClushTest.py
+++ b/tests/CLIClushTest.py
@@ -541,6 +541,7 @@ class CLIClushTest_A(unittest.TestCase):
                        "echo foo >&2; echo bar; sleep 2"], None,
                       s.encode(), 0, re.compile(err_rxs.encode()))
 
+    @unittest.skipIf(which('pdsh') is None, "pdsh is not installed")
     def test_032_worker_pdsh(self):
         """test clush (worker pdsh)"""
         # Warning: same as: echo -n | clush --worker=pdsh when launched from
@@ -552,6 +553,7 @@ class CLIClushTest_A(unittest.TestCase):
         self.assertRaises(EngineClientNotSupportedError, self._clush_t,
                           ["-w", HOSTNAME, "-R", "pdsh", "cat"], b"bar", None, 1)
 
+    @unittest.skipIf(which('pdsh') is None, "pdsh is not installed")
     def test_033_worker_pdsh_tty(self):
         """test clush (worker pdsh) [tty]"""
         setattr(ClusterShell.CLI.Clush, '_f_user_interaction', True)

--- a/tests/TLib.py
+++ b/tests/TLib.py
@@ -18,11 +18,20 @@ except ImportError:
 from io import BytesIO, StringIO
 
 
-__all__ = ['HOSTNAME', 'load_cfg', 'make_temp_filename', 'make_temp_file',
-           'make_temp_dir', 'CLI_main']
+__all__ = ['HOSTNAME', 'which', 'load_cfg', 'make_temp_filename',
+           'make_temp_file', 'make_temp_dir', 'CLI_main']
 
 # Get machine short hostname
 HOSTNAME = socket.gethostname().split('.', 1)[0]
+
+# Replace with shutil.which() once we only support Py3.3+
+def which(program):
+    """Return path of first executable program found in PATH, or None."""
+    for path in os.environ.get('PATH', '').split(os.pathsep):
+        fpath = os.path.join(path, program)
+        if os.path.isfile(fpath) and os.access(fpath, os.X_OK):
+            return fpath
+    return None
 
 class TBytesIO(BytesIO):
     """Standard stream of in memory bytes for testing purpose."""

--- a/tests/TaskDistantPdshTest.py
+++ b/tests/TaskDistantPdshTest.py
@@ -12,11 +12,13 @@ from ClusterShell.Engine.EPoll import EngineEPoll
 from ClusterShell.Task import *
 
 from .TaskDistantPdshMixin import TaskDistantPdshMixin
+from .TLib import which
 
 ENGINE_SELECT_ID = EngineSelect.identifier
 ENGINE_POLL_ID = EnginePoll.identifier
 ENGINE_EPOLL_ID = EngineEPoll.identifier
 
+@unittest.skipIf(which('pdsh') is None, "pdsh is not installed")
 class TaskDistantPdshEngineSelectTest(TaskDistantPdshMixin, unittest.TestCase):
 
     def setUp(self):
@@ -31,6 +33,7 @@ class TaskDistantPdshEngineSelectTest(TaskDistantPdshMixin, unittest.TestCase):
         DEFAULTS.engine = self.engine_id_save
         task_terminate()
 
+@unittest.skipIf(which('pdsh') is None, "pdsh is not installed")
 class TaskDistantPdshEnginePollTest(TaskDistantPdshMixin, unittest.TestCase):
 
     def setUp(self):
@@ -49,6 +52,7 @@ class TaskDistantPdshEnginePollTest(TaskDistantPdshMixin, unittest.TestCase):
 # removed once we only support Py2.6+)
 if sys.version_info >= (2, 6, 0):
 
+    @unittest.skipIf(which('pdsh') is None, "pdsh is not installed")
     class TaskDistantPdshEngineEPollTest(TaskDistantPdshMixin, unittest.TestCase):
 
         def setUp(self):

--- a/tests/TaskRLimitsTest.py
+++ b/tests/TaskRLimitsTest.py
@@ -6,7 +6,7 @@
 import resource
 import unittest
 
-from .TLib import HOSTNAME
+from .TLib import HOSTNAME, which
 from ClusterShell.Task import *
 from ClusterShell.Worker.Pdsh import WorkerPdsh
 
@@ -67,10 +67,12 @@ class TaskRLimitsTest(unittest.TestCase):
         # run task
         task.resume()
 
+    @unittest.skipIf(which('pdsh') is None, "pdsh is not installed")
     def testRemotePdsh(self):
         """test resource usage with WorkerPdsh(stderr=False)"""
         self._testRemotePdsh(False)
 
+    @unittest.skipIf(which('pdsh') is None, "pdsh is not installed")
     def testRemotePdshStderr(self):
         """test resource usage with WorkerPdsh(stderr=True)"""
         self._testRemotePdsh(True)


### PR DESCRIPTION
Running the test suite on a host without pdsh is currently fatal: in `test_033_worker_pdsh_tty`, clush's tty code path runs the command in a separate task thread; the failed pdsh spawn raises `WorkerError("Cannot run pdsh (error 255)")` there, which reaches `clush_excepthook` and ends in `os._exit(1)` — silently killing the whole unittest process mid-test. Watching the suite log, this looks like a hang (the log freezes at `test_033 ...` with no result; the error message is lost in the captured stderr).

- add a small `which()` helper to tests/TLib.py
- skip with `@unittest.skipIf(which('pdsh') is None, ...)`: the three `TaskDistantPdshTest` classes, `CLIClushTest` `test_032`/`test_033`, and the two `TaskRLimitsTest` WorkerPdsh tests
- CI installs pdsh explicitly (tests.yml "Install pdsh to test WorkerPdsh"), so CI coverage is unchanged; this only fixes runs on dev machines

Verified without pdsh installed: all guarded tests now skip and the suite completes normally; with pdsh present the guards are no-ops.