### PR TITLE
doc: clarify '*' all-nodes wildcard vs literal 'all' group source

### DIFF
--- a/conf/groups.d/cluster.yaml.example
+++ b/conf/groups.d/cluster.yaml.example
@@ -24,6 +24,7 @@ roles:
     io: '@racks:rack2,example2'
     compute: '@racks:rack[3-4]'
     gpu: '@racks:rack4'
+    # '*' is the all-nodes wildcard, e.g. @roles:* or clush -a, not 'all'
     # the 'all' special group is only needed if we don't want all nodes from
     # this group source included, here we don't want example0 for clush -a
     all: '@io,@compute'

--- a/doc/sphinx/config.rst
+++ b/doc/sphinx/config.rst
@@ -359,6 +359,20 @@ Here is an example of **/etc/clustershell/groups.d/cluster.yaml**::
 If you wish to define an empty group (with no nodes), you can either use an
 empty string ``''`` or any valid YAML null value (``null`` or ``~``).
 
+.. note::
+
+   To select **every node** of a group source, use the ``*`` wildcard, for
+   example ``@lustre:*`` or, for the default source, ``@*``. This is the
+   *all nodes* notation also used by ``clush -a`` and ``nodeset -a``, as
+   described in :ref:`group-sources-upcalls`. The word ``all`` is not special:
+   it is an ordinary group name, so ``@lustre:*`` and ``@lustre:all`` are
+   **not** equivalent. ``@lustre:all`` resolves the group literally named
+   ``all``, which yields an empty node set here because ``lustre`` defines no
+   such group. By default *all nodes* is the union of every group in the
+   source. Defining an optional ``all`` group, like the ``all:`` key shown
+   above in the ``roles`` source, overrides that union for both ``-a`` and
+   ``@source:*``.
+
 .. highlight:: console
 
 Testing the syntax of your group file can be quickly performed through the


### PR DESCRIPTION
Documentation-only fix for #552.

The all-nodes selector in group sources is the `*` wildcard, written `@source:*`, or `@*` for the default source, and also reachable via `clush -a` and `nodeset -a`. The literal `all` is just an ordinary group name, so `@source:all` resolves to an empty node set unless an `all` group is actually defined.

- `config.rst`: note in the "YAML group files" section, cross-referencing the group source upcalls section.
- `cluster.yaml.example`: one-line comment by the `all:` example.
