### PR TITLE
Tree: separate stderr on forward copy to isolate tar/scp errors

### DIFF
--- a/lib/ClusterShell/Task.py
+++ b/lib/ClusterShell/Task.py
@@ -643,6 +643,10 @@ class Task(object):
     def copy(self, source, dest, nodes, **kwargs):
         """
         Copy local file to distant nodes.
+
+        Note: in tree mode, copy and rcopy always separate stderr so that
+        the internal tar/scp error messages are not merged into stdout; an
+        explicit stderr=False is then ignored.
         """
         assert nodes != None, "local copy not supported"
 

--- a/lib/ClusterShell/Worker/Tree.py
+++ b/lib/ClusterShell/Worker/Tree.py
@@ -184,9 +184,9 @@ class TreeWorker(DistantWorker):
             raise ValueError("missing command or source parameter in "
                              "TreeWorker constructor")
 
-        # rcopy is enforcing separated stderr to handle tar error messages
-        # because stdout is used for data transfer
-        if self.source and self.reverse:
+        # copy/rcopy: keep internal tar/scp errors on a separate stderr stream
+        # instead of merging them into stdout (which also carries rcopy data)
+        if self.source:
             self.stderr = True
 
         # build gateway invocation command

--- a/tests/TreeWorkerTest.py
+++ b/tests/TreeWorkerTest.py
@@ -54,6 +54,7 @@ class TEventHandlerBase(EventHandler):
         self.ev_close_cnt = 0
         self.ev_timedout_cnt = 0
         self.last_read = None
+        self.read_snames = set()
 
 
 class TEventHandlerLegacy(TEventHandlerBase):
@@ -95,6 +96,7 @@ class TEventHandler(TEventHandlerBase):
     def ev_read(self, worker, node, sname, msg):
         self.ev_read_cnt += 1
         self.last_read = msg
+        self.read_snames.add(sname)
 
     def ev_written(self, worker, node, sname, size):
         self.ev_written_cnt += 1
@@ -194,6 +196,32 @@ class TreeWorkerTestBase(unittest.TestCase):
             with open(dest, 'r') as destf:
                 self.assertEqual(destf.read(), 'Lorem Ipsum')
         finally:
+            if os.path.exists(dest):
+                os.remove(dest)
+
+    def _tree_copy_file_error(self, target):
+        """helper to copy file to a bad dest (untar/scp error -> stderr)"""
+        teh = TEventHandler()
+        srcf = make_temp_file(b'Lorem Ipsum', 'test_tree_copy_file_src')
+        # parent dir is removed so the remote scp/untar fails on every target
+        destdir = make_temp_dir()
+        dest = join(destdir.name, 'destfile')
+        destdir.cleanup()
+        try:
+            worker = self.task.copy(srcf.name, dest, nodes=target, handler=teh)
+            self.task.run()
+            target_cnt = len(NodeSet(target))
+            self.assertEqual(teh.ev_start_cnt, 1)
+            self.assertEqual(teh.ev_pickup_cnt, target_cnt)
+            self.assertEqual(teh.ev_hup_cnt, target_cnt)
+            self.assertEqual(teh.ev_timedout_cnt, 0)
+            self.assertEqual(teh.ev_close_cnt, 1)
+            # the copy failed: error output must be attributed to stderr only,
+            # not merged into stdout (GH #622)
+            self.assertTrue(teh.ev_read_cnt > 0)
+            self.assertEqual(teh.read_snames, set([worker.SNAME_STDERR]))
+        finally:
+            srcf.close()
             if os.path.exists(dest):
                 os.remove(dest)
 
@@ -534,6 +562,18 @@ class TreeWorkerTest(TreeWorkerTestBase):
     def test_tree_copy_file_gateway(self):
         """test tree copy: file, gateway is target"""
         self._tree_copy_file(NODE_GATEWAY)
+
+    def test_tree_copy_file_error_direct(self):
+        """test tree copy: bad dest, direct target -> stderr (#622)"""
+        self._tree_copy_file_error(NODE_DIRECT)
+
+    def test_tree_copy_file_error_distant(self):
+        """test tree copy: bad dest, distant target via gateway -> stderr (#622)"""
+        self._tree_copy_file_error(NODE_DISTANT)
+
+    def test_tree_copy_file_error_distant2(self):
+        """test tree copy: bad dest, distant 2 targets via gateway -> stderr (#622)"""
+        self._tree_copy_file_error(NODE_DISTANT2)
 
     def test_tree_copy_dir_distant(self):
         """test tree copy: directory, distant target"""


### PR DESCRIPTION
Tree copy ran an internal `tar -xf -` (gateway-routed targets) or `scp` (directly-reached targets) under the task default `stderr=False`, so their error messages were merged into stdout, indistinguishable from command output (this surfaced as unexpected read events in #621).

Fix: force separated stderr for forward copy in `TreeWorker`, matching the rcopy behavior. An explicit `stderr=False` is overridden for tree copies, as with rcopy. Also documents the behavior in `Task.copy()` and adds regression tests for the scp (direct) and tar (single + multi-node gateway) paths.
