### PR TITLE
Clush, Clubak: add --axis option to choose nD fold axis

### DIFF
--- a/doc/man/man1/clubak.1
+++ b/doc/man/man1/clubak.1
@@ -68,6 +68,9 @@ disable header block and order output by nodes
 .B  \-r\fP,\fB  \-\-regroup
 fold nodeset using node groups
 .TP
+.BI \-\-axis\fB= RANGESET
+for nD nodesets, fold the displayed nodeset (eg. in gathered output headers) along provided axis only. Axis are indexed from 1 to n and can be specified here either using the rangeset syntax, eg. \(aq1\(aq, \(aq1\-2\(aq, \(aq1,3\(aq, or by a single negative number meaning that the index is counted from the end. Because some nodesets may have several different dimensions, axis indices are silently truncated to fall in the allowed range. This is the per\-invocation equivalent of the \fBfold_axis\fP library default.
+.TP
 .BI \-s \ GROUPSOURCE\fR,\fB \ \-\-groupsource\fB= GROUPSOURCE
 optional \fBgroups.conf\fP(5) group source to use
 .TP

--- a/doc/man/man1/clush.1
+++ b/doc/man/man1/clush.1
@@ -237,6 +237,9 @@ like \-b but including standard error
 .B  \-r\fP,\fB  \-\-regroup
 fold nodeset using node groups
 .TP
+.BI \-\-axis\fB= RANGESET
+for nD nodesets, fold the displayed nodeset (eg. in gathered output headers) along provided axis only. Axis are indexed from 1 to n and can be specified here either using the rangeset syntax, eg. \(aq1\(aq, \(aq1\-2\(aq, \(aq1,3\(aq, or by a single negative number meaning that the index is counted from the end. Because some nodesets may have several different dimensions, axis indices are silently truncated to fall in the allowed range. This is the per\-invocation equivalent of the \fBfold_axis\fP library default.
+.TP
 .B  \-S\fP,\fB  \-\-maxrc
 return the largest of command return codes
 .TP
@@ -343,6 +346,9 @@ Search some files on node32 in /etc/yum.repos.d and use clush to list the matchi
 .TP
 .B # clush \-w node[3\-5,62] \-\-diff dmidecode \-s bios\-version
 Run this Linux command to get BIOS version on nodes[3\-5,62] and show version differences (if any).
+.TP
+.B # clush \-w dc[1\-2]n[1\-2] \-\-axis=1 \-b uname \-r
+Gather output and fold the displayed nodeset header along axis 1 only, eg. show \fBdc[1\-2]n1,dc[1\-2]n2\fP rather than \fBdc[1\-2]n[1\-2]\fP in the header block. See also \fBfold_axis\fP in the Library Defaults configuration to change it permanently.
 .UNINDENT
 .SS All nodes
 .INDENT 0.0

--- a/doc/sphinx/config.rst
+++ b/doc/sphinx/config.rst
@@ -771,6 +771,11 @@ folding is only computed on the last axis (seems to work best with Slurm)::
 That way, node sets computed by ClusterShell tools can be passed to Slurm
 without error.
 
+Since this only affects how node sets are folded for display, you may also fold
+along a single axis per invocation with the ``--axis`` option of
+:ref:`nodeset <nodeset-tool>`, :ref:`cluset <cluset-tool>` and
+:ref:`clush <clush-axis>`, instead of setting ``fold_axis`` here.
+
 .. _ConfigParser: http://docs.python.org/library/configparser.html
 .. _nodeset: https://xcat-docs.readthedocs.io/en/stable/guides/admin-guides/references/man8/nodeset.8.html
 .. _sys.prefix: https://docs.python.org/3/library/sys.html#sys.prefix

--- a/doc/sphinx/tools/clubak.rst
+++ b/doc/sphinx/tools/clubak.rst
@@ -52,6 +52,9 @@ node groups in results, use ``-r, --regroup``::
 
     $ clubak -br < file
 
+Likewise, the ``--axis`` option folds the displayed node set along selected
+*nD* axis only, as described in :ref:`clush-axis`.
+
 Like *clush*, *clubak* uses the :mod:`ClusterShell.MsgTree` module of the ClusterShell
 library.
 

--- a/doc/sphinx/tools/clush.rst
+++ b/doc/sphinx/tools/clush.rst
@@ -393,6 +393,32 @@ even if all nodes have successfully run the command. When you hit CTRL-C with
     2.6.18-164.11.1.el5
     Keyboard interrupt (node1 did not complete).
 
+.. _clush-axis:
+
+Choosing fold axis (nD)
+"""""""""""""""""""""""
+
+When displaying gathered results for multidimensional node sets, *clush* folds
+the nodeset header along all *nD* axis by default. As other cluster tools
+barely support nD nodeset syntax, the ``--axis`` option lets you fold the
+displayed nodeset along one (or a few) axis only. ``--axis`` value is a set of
+integers from 1 to n representing selected nD axis, in the form of a number or
+a rangeset (eg. ``1``, ``1-2``, ``1,3``); a single negative number folds along
+the last axis whatever the number of dimensions used. Because a node set may
+have several different dimensions, axis indices are silently truncated to fall
+in the allowed range. For example, to gather output but fold the header along
+the first axis only::
+
+    $ clush -b --axis=1 -w dc[1-2]n[1-2] uname -r
+    ---------------
+    dc[1-2]n1,dc[1-2]n2 (4)
+    ---------------
+    5.14.0-503.el9.x86_64
+
+This is the per-invocation equivalent of the ``fold_axis`` library default;
+see also the :ref:`defaults-config-slurm` of Library Defaults for changing it
+permanently.
+
 .. _clush-diff:
 
 Performing *diff* of cluster-wide outputs

--- a/doc/txt/clubak.txt
+++ b/doc/txt/clubak.txt
@@ -47,6 +47,8 @@ OPTIONS
 -d, --debug    output more messages for debugging purpose
 -L             disable header block and order output by nodes
 -r, --regroup  fold nodeset using node groups
+--axis=RANGESET
+               for nD nodesets, fold the displayed nodeset (eg. in gathered output headers) along provided axis only. Axis are indexed from 1 to n and can be specified here either using the rangeset syntax, eg. '1', '1-2', '1,3', or by a single negative number meaning that the index is counted from the end. Because some nodesets may have several different dimensions, axis indices are silently truncated to fall in the allowed range. This is the per-invocation equivalent of the ``fold_axis`` library default.
 -s GROUPSOURCE, --groupsource=GROUPSOURCE
                optional ``groups.conf``\(5) group source to use
 --groupsconf=FILE

--- a/doc/txt/clush.txt
+++ b/doc/txt/clush.txt
@@ -162,6 +162,7 @@ Output behaviour:
   -b, --dshbak        display gathered results in a dshbak-like way (note: it will only try to aggregate the output of commands with same return codes)
   -B                  like -b but including standard error
   -r, --regroup       fold nodeset using node groups
+  --axis=RANGESET     for nD nodesets, fold the displayed nodeset (eg. in gathered output headers) along provided axis only. Axis are indexed from 1 to n and can be specified here either using the rangeset syntax, eg. '1', '1-2', '1,3', or by a single negative number meaning that the index is counted from the end. Because some nodesets may have several different dimensions, axis indices are silently truncated to fall in the allowed range. This is the per-invocation equivalent of the ``fold_axis`` library default.
   -S, --maxrc         return the largest of command return codes
   --color=WHENCOLOR   ``clush`` can use NO_COLOR, CLICOLOR and CLICOLOR_FORCE environment variables. NO_COLOR takes precedence over CLICOLOR_FORCE which takes precedence over CLICOLOR.  When ``--color`` option is used these environment variables are not taken into account. ``--color`` tells whether to use ANSI colors to surround node or nodeset prefix/header with escape sequences to display them in color on the terminal. *WHENCOLOR* is ``never``, ``always`` or ``auto`` (which use color if standard output/error refer to a terminal). Colors are set to [34m (blue foreground text) for stdout and [31m (red foreground text) for stderr, and cannot be modified.
   --diff              show diff between common outputs (find the best reference output by focusing on largest nodeset and also smaller command return code)
@@ -241,6 +242,9 @@ Display features
 
 :# clush -w node[3-5,62] --diff dmidecode -s bios-version:
     Run this Linux command to get BIOS version on nodes[3-5,62] and show version differences (if any).
+
+:# clush -w dc[1-2]n[1-2] --axis=1 -b uname -r:
+    Gather output and fold the displayed nodeset header along axis 1 only, eg. show ``dc[1-2]n1,dc[1-2]n2`` rather than ``dc[1-2]n[1-2]`` in the header block. See also ``fold_axis`` in the Library Defaults configuration to change it permanently.
 
 All nodes
 ---------

--- a/lib/ClusterShell/CLI/Clubak.py
+++ b/lib/ClusterShell/CLI/Clubak.py
@@ -29,6 +29,7 @@ from __future__ import print_function
 
 import sys
 
+from ClusterShell.Defaults import DEFAULTS
 from ClusterShell.MsgTree import MsgTree, MODE_DEFER, MODE_TRACE
 from ClusterShell.NodeSet import NodeSet, NodeSetParseError, std_group_resolver
 from ClusterShell.NodeSet import set_std_group_resolver_config
@@ -37,7 +38,7 @@ from ClusterShell.CLI.Display import Display, THREE_CHOICES
 from ClusterShell.CLI.Display import sys_stdin
 from ClusterShell.CLI.Error import GENERIC_ERRORS, handle_generic_error
 from ClusterShell.CLI.OptionParser import OptionParser
-from ClusterShell.CLI.Utils import nodeset_cmpkey
+from ClusterShell.CLI.Utils import nodeset_cmpkey, parse_fold_axis
 
 
 def display_tree(tree, disp, out):
@@ -101,6 +102,10 @@ def clubak():
     options = parser.parse_args()[0]
 
     set_std_group_resolver_config(options.groupsconf)
+
+    # User-specified nD-nodeset fold axis for output display (#356)
+    if options.axis:
+        DEFAULTS.fold_axis = parse_fold_axis(options.axis)
 
     if options.interpret_keys == THREE_CHOICES[-1]: # auto?
         enable_nodeset_key = None # AUTO

--- a/lib/ClusterShell/CLI/Clush.py
+++ b/lib/ClusterShell/CLI/Clush.py
@@ -57,7 +57,8 @@ from ClusterShell.CLI.Display import Display, sys_stdin
 from ClusterShell.CLI.Display import VERB_QUIET, VERB_STD, VERB_VERB, VERB_DEBUG
 from ClusterShell.CLI.OptionParser import OptionParser
 from ClusterShell.CLI.Error import GENERIC_ERRORS, handle_generic_error
-from ClusterShell.CLI.Utils import bufnodeset_cmpkey, human_bi_bytes_unit
+from ClusterShell.CLI.Utils import bufnodeset_cmpkey, human_bi_bytes_unit, \
+    parse_fold_axis
 
 from ClusterShell.Event import EventHandler
 from ClusterShell.MsgTree import MsgTree
@@ -943,6 +944,10 @@ def main():
 
     # Specified engine prevails over default engine
     DEFAULTS.engine = options.engine
+
+    # User-specified nD-nodeset fold axis for output display (#356)
+    if options.axis:
+        DEFAULTS.fold_axis = parse_fold_axis(options.axis)
 
     # Do we have nodes group?
     task = task_self()

--- a/lib/ClusterShell/CLI/Nodeset.py
+++ b/lib/ClusterShell/CLI/Nodeset.py
@@ -35,6 +35,7 @@ import sys
 
 from ClusterShell.CLI.Error import GENERIC_ERRORS, handle_generic_error
 from ClusterShell.CLI.OptionParser import OptionParser
+from ClusterShell.CLI.Utils import parse_fold_axis
 
 from ClusterShell.NodeSet import NodeSet, RangeSet, std_group_resolver
 from ClusterShell.NodeSet import grouplist, set_std_group_resolver_config
@@ -299,13 +300,7 @@ def nodeset():
 
     # user-specified nD-nodeset fold axis
     if options.axis:
-        if not options.axis.startswith('-'):
-            # axis are 1-indexed in nodeset CLI (0 ignored)
-            xset.fold_axis = tuple(x-1 for x in \
-                                   RangeSet(options.axis).intiter() if x > 0)
-        else:
-            # negative axis index (only single number supported)
-            xset.fold_axis = [int(options.axis)]
+        xset.fold_axis = parse_fold_axis(options.axis)
 
     if options.pick and options.pick < len(xset):
         # convert to string for sample as nsiter() is slower for big

--- a/lib/ClusterShell/CLI/OptionParser.py
+++ b/lib/ClusterShell/CLI/OptionParser.py
@@ -165,6 +165,10 @@ class OptionParser(optparse.OptionParser):
         optgrp.add_option("-r", "--regroup", action="store_true",
                           dest="regroup", default=False,
                           help="fold nodeset using node groups")
+        optgrp.add_option("--axis", action="store", dest="axis",
+                          metavar="RANGESET",
+                          help="fold along these axis only "
+                               "(axis 1..n for nD nodeset)")
 
         if separator_option:
             optgrp.add_option("-S", "--separator", action="store",

--- a/lib/ClusterShell/CLI/Utils.py
+++ b/lib/ClusterShell/CLI/Utils.py
@@ -22,6 +22,18 @@
 CLI utility functions
 """
 
+from ClusterShell.RangeSet import RangeSet
+
+
+def parse_fold_axis(axis):
+    """Translate a 1-indexed command-line --axis value to a 0-indexed
+    fold_axis suitable for NodeSet.fold_axis or Defaults.fold_axis."""
+    if not axis.startswith('-'):
+        # axis are 1-indexed on the command line (0 ignored)
+        return tuple(x - 1 for x in RangeSet(axis).intiter() if x > 0)
+    # negative axis index (only single number supported)
+    return [int(axis)]
+
 
 (KIBI, MEBI, GIBI, TEBI) = (1024.0, 1024.0 ** 2, 1024.0 ** 3, 1024.0 ** 4)
 

--- a/tests/CLIClubakTest.py
+++ b/tests/CLIClubakTest.py
@@ -9,6 +9,7 @@ import unittest
 
 from .TLib import *
 from ClusterShell.CLI.Clubak import main
+from ClusterShell.Defaults import DEFAULTS
 
 from ClusterShell.NodeSet import set_std_group_resolver, \
                                  set_std_group_resolver_config
@@ -179,6 +180,37 @@ class CLIClubakTest(unittest.TestCase):
         # GH #400
         self._clubak_t(["--diff"], b"host1: \xc3\xa5\nhost2: a\nhost2: b\nhost1: b\n",
                        b"--- host1\n+++ host2\n@@ -1,2 +1,2 @@\n- \xc3\xa5\n+ a\n  b\n")
+
+    def test_010_axis(self):
+        """test clubak --axis (fold gathered output along selected axis)"""
+        # 2D node keys with identical content gather into a single block
+        # whose header folds along the requested axis.
+        nd = b"foo1-1: bar\nfoo1-2: bar\nfoo2-1: bar\nfoo2-2: bar\n"
+        fold_axis_save = DEFAULTS.fold_axis
+        try:
+            DEFAULTS.fold_axis = ()
+            # no --axis: fold along all axis (default)
+            self._clubak_t(["-b"], nd,
+                           b"---------------\nfoo[1-2]-[1-2] (4)\n"
+                           b"---------------\n bar\n")
+            # --axis=1: fold first dimension only
+            self._clubak_t(["--axis=1", "-b"], nd,
+                           b"---------------\nfoo[1-2]-1,foo[1-2]-2 (4)\n"
+                           b"---------------\n bar\n")
+            # --axis=2: fold second dimension only
+            self._clubak_t(["--axis=2", "-b"], nd,
+                           b"---------------\nfoo1-[1-2],foo2-[1-2] (4)\n"
+                           b"---------------\n bar\n")
+            # --axis=-1: fold last dimension only
+            self._clubak_t(["--axis=-1", "-b"], nd,
+                           b"---------------\nfoo1-[1-2],foo2-[1-2] (4)\n"
+                           b"---------------\n bar\n")
+            # interpret-keys=never: raw key, --axis is a no-op
+            self._clubak_t(["--axis=1", "--interpret-keys=never", "-b"],
+                           b"foo1-1: bar\n",
+                           b"---------------\nfoo1-1\n---------------\n bar\n")
+        finally:
+            DEFAULTS.fold_axis = fold_axis_save
 
 
 class CLIClubakTestGroupsConf(CLIClubakTest):

--- a/tests/CLIClushTest.py
+++ b/tests/CLIClushTest.py
@@ -23,6 +23,7 @@ from subprocess import Popen, PIPE
 from .TLib import *
 import ClusterShell.CLI.Clush
 from ClusterShell.CLI.Clush import main
+from ClusterShell.Defaults import DEFAULTS
 from ClusterShell.NodeSet import NodeSet
 from ClusterShell.NodeSet import set_std_group_resolver, \
                                  set_std_group_resolver_config
@@ -789,6 +790,38 @@ class CLIClushTest_A(unittest.TestCase):
         self.assertGreater(spread, 0.5,
                            "lines arrived together (spread=%.3fs); "
                            "clush stdout looks block-buffered" % spread)
+
+    def test_046_axis(self):
+        """test clush --axis (fold gathered output along selected axis)"""
+        # 2D nodeset gathered locally via exec worker; all hosts emit the
+        # same output, so the folded header reflects the requested axis.
+        base = ["-R", "exec", "-w", "foo[1-2]-[1-2]", "-b", "echo test"]
+        fold_axis_save = DEFAULTS.fold_axis
+        try:
+            DEFAULTS.fold_axis = ()
+            # no --axis: fold along all axis (default)
+            self._clush_t(base, b"",
+                          b"---------------\nfoo[1-2]-[1-2] (4)\n"
+                          b"---------------\ntest\n")
+            # --axis=1: fold first dimension only
+            self._clush_t(["--axis=1"] + base, b"",
+                          b"---------------\nfoo[1-2]-1,foo[1-2]-2 (4)\n"
+                          b"---------------\ntest\n")
+            # --axis=2: fold second dimension only
+            self._clush_t(["--axis=2"] + base, b"",
+                          b"---------------\nfoo1-[1-2],foo2-[1-2] (4)\n"
+                          b"---------------\ntest\n")
+            # --axis=-1: fold last dimension only
+            self._clush_t(["--axis=-1"] + base, b"",
+                          b"---------------\nfoo1-[1-2],foo2-[1-2] (4)\n"
+                          b"---------------\ntest\n")
+            # 1D nodeset still folds normally with --axis=1
+            self._clush_t(["--axis=1", "-R", "exec", "-w", "node[1-4]", "-b",
+                           "echo test"], b"",
+                          b"---------------\nnode[1-4] (4)\n"
+                          b"---------------\ntest\n")
+        finally:
+            DEFAULTS.fold_axis = fold_axis_save
 
 
 class CLIClushTest_B_StdinFailure(unittest.TestCase):


### PR DESCRIPTION
Adds `--axis` to `clush` and `clubak`, the per-invocation equivalent of the
`fold_axis` library default, to fold displayed (gathered-header) node sets
along selected nD axis only — useful for tools (e.g. Slurm) that don't parse
all nD node set forms. `nodeset`/`cluset` already had `--axis`.

- `--axis` translated 1-indexed → 0-indexed `DEFAULTS.fold_axis` (clush/clubak)
- translation factored into a shared `CLI.Utils.parse_fold_axis()` helper, also
  adopted by the existing `nodeset`/`cluset` `--axis` (de-duplicated)
- man + sphinx docs (`clush.rst`, `clubak.rst`, Slurm use case in `config.rst`)
- SSH-free tests for both tools (exec worker / stdin)

Implements #356.
