### PR TITLE
Engine: fix set_events debug to log the client, not the engine

### DIFF
--- a/lib/ClusterShell/Engine/Engine.py
+++ b/lib/ClusterShell/Engine/Engine.py
@@ -634,7 +634,8 @@ class Engine(object):
             (stream.new_events, stream.events, client, stream.name))
 
         if not client.registered:
-            LOGGER.debug("set_events: client %s not registered", self)
+            LOGGER.debug("set_events: client %s[%s] not registered",
+                         client, stream.name)
             return
 
         chgbits = stream.new_events ^ stream.events


### PR DESCRIPTION
`Engine.set_events()`'s not-registered debug line logged the engine (`self`) instead of the client; it now logs the client and stream name. Kept rather than removed as a guard for abnormal use, since its common trigger — writing from `ev_start` before registration (e.g. `test_write_on_ev_start`) — is deterministic and harmless: `register()` re-arms write interest right after `_start()`, so nothing is lost.
