### PR TITLE
NodeSet, RangeSet: add list-like index() method (#631)

### DIFF
--- a/lib/ClusterShell/NodeSet.py
+++ b/lib/ClusterShell/NodeSet.py
@@ -479,6 +479,85 @@ class NodeSetBase(object):
         else:
             raise TypeError("NodeSet indices must be integers")
 
+    def _rangeset_index(self, rangeset, orangeset):
+        """Return the position of the single index held by `orangeset`
+        within `rangeset`, following the same order as iteration, or None
+        if the index is not contained in `rangeset`.
+
+        Both arguments are the RangeSet/RangeSetND/None objects respectively
+        associated to the same pattern in this nodeset and in the searched
+        single node.
+        """
+        # unnumbered node (eg. 'server'): both must have no index
+        if rangeset is None or orangeset is None:
+            return 0 if rangeset is None and orangeset is None else None
+
+        try:
+            if isinstance(orangeset, RangeSetND):
+                # nD: orangeset holds a single index vector
+                return rangeset.index(next(iter(orangeset)))
+            # 1D: orangeset holds a single (possibly zero-padded) index
+            return rangeset.index(next(orangeset.striter()))
+        except ValueError:
+            return None
+
+    def index(self, other, start=0, stop=None):
+        """Return the zero-based index in the nodeset of the node `other`.
+
+        This behaves like the ``index()`` method of the ``list`` type: it
+        returns the position of the node when iterating over the nodeset and
+        raises a :class:`ValueError` if the node is not present. The optional
+        `start` and `stop` arguments restrict the search to the matching
+        subsequence, and may be negative (counted from the end).
+
+        Unlike a naive linear search, this implementation does not expand the
+        whole nodeset: it only sums the size of the patterns that precede the
+        searched node and locates it within its own pattern.
+
+        Example:
+           >>> NodeSetBase('node%s', RangeSet('0-9,20')).index(
+           ...     NodeSetBase('node%s', RangeSet('20')))
+           10
+        """
+        self._binary_sanity_check(other)
+        if len(other) != 1:
+            raise ValueError("index() argument must be a single node")
+
+        # extract the single (pattern, rangeset) of the searched node
+        opat, orangeset = list(other._patterns.items())[0]
+
+        # walk patterns in iteration order, summing sizes until we reach the
+        # pattern of the searched node
+        found = None
+        base = 0
+        for pat, rangeset in sorted(self._patterns.items()):
+            if pat == opat:
+                offset = self._rangeset_index(rangeset, orangeset)
+                if offset is not None:
+                    found = base + offset
+                break
+            if rangeset:
+                base += len(rangeset)
+            else:
+                base += 1
+
+        if found is None:
+            raise ValueError("'%s' is not in nodeset" % other)
+
+        # honor optional start/stop search window (list.index() semantics)
+        if start != 0 or stop is not None:
+            length = len(self)
+            if start < 0:
+                start = max(0, length + start)
+            if stop is None:
+                stop = length
+            elif stop < 0:
+                stop = max(0, length + stop)
+            if not start <= found < stop:
+                raise ValueError("'%s' is not in nodeset" % other)
+
+        return found
+
     def _add_new(self, pat, rangeset):
         """Add nodes from a (pat, rangeset) tuple.
         Predicate: pattern does not exist in current set. RangeSet object is
@@ -1479,6 +1558,23 @@ class NodeSet(NodeSetBase):
         inst = NodeSet(autostep=self._autostep, resolver=self._resolver)
         inst._patterns = base._patterns
         return inst
+
+    def index(self, other, start=0, stop=None):
+        """Return the zero-based index in the nodeset of the node `other`.
+
+        Like the ``index()`` method of the ``list`` type, this returns the
+        position of `other` when iterating over the nodeset and raises a
+        :class:`ValueError` if the node is not present. The optional `start`
+        and `stop` arguments restrict the search and may be negative.
+
+        The `other` argument is a single node and may be provided as a string
+        (it is parsed, so node groups are resolved if any).
+
+        >>> NodeSet("node[0-9,20]").index("node20")
+        10
+        """
+        nodeset = self._parser.parse(other, self._autostep)
+        return NodeSetBase.index(self, nodeset, start, stop)
 
     def split(self, nbr):
         """

--- a/lib/ClusterShell/RangeSet.py
+++ b/lib/ClusterShell/RangeSet.py
@@ -30,6 +30,24 @@ from functools import reduce
 from itertools import product
 from operator import mul
 
+# Python 3 compatibility
+try:
+    basestring
+except NameError:
+    basestring = str
+
+
+def _normalized_index_bounds(length, start, stop):
+    """Return list.index()-like normalized start/stop bounds."""
+    if start < 0:
+        start = max(0, length + start)
+    if stop is None:
+        stop = length
+    elif stop < 0:
+        stop = max(0, length + stop)
+    return start, stop
+
+
 __all__ = ['RangeSetException',
            'RangeSetParseError',
            'RangeSetPaddingError',
@@ -281,12 +299,18 @@ class RangeSet(set):
         the object is empty, in that case it will return 0."""
         return int(len(self) > 0)
 
+    @staticmethod
+    def _sortkey(elem):
+        """Sort key used to order RangeSet elements (mixed padding support):
+        sort by both string length and index."""
+        if elem.startswith('-'):
+            return (-len(elem), int(elem))
+        return (len(elem), elem)
+
     def _sorted(self):
         """Get sorted list from inner set."""
         # For mixed padding support, sort by both string length and index
-        return sorted(set.__iter__(self),
-                      key=lambda x: (-len(x), int(x)) if x.startswith('-') \
-                                    else (len(x), x))
+        return sorted(set.__iter__(self), key=self._sortkey)
 
     def __iter__(self):
         """Iterate over each element in RangeSet, currently as integers, with
@@ -509,6 +533,37 @@ class RangeSet(set):
             raise TypeError("%s indices must be integers" %
                             self.__class__.__name__)
 
+    def index(self, elem, start=0, stop=None):
+        """
+        Return the zero-based index of element in the sorted RangeSet.
+
+        This is the reverse operation of :meth:`RangeSet.__getitem__` and
+        behaves like the ``index()`` method of the ``list`` type. The element
+        may be given as a string (zero-padding is then significant) or as an
+        integer. The optional `start` and `stop` arguments restrict the search
+        to the matching subsequence, and may be negative (counted from the
+        end).
+
+        :raises ValueError: the element is not present in the RangeSet
+        """
+        if isinstance(elem, basestring):
+            key = elem
+        else:
+            key = str(elem)
+        # set membership is fast and padding-aware for strings
+        if not set.__contains__(self, key):
+            raise ValueError("%s is not in RangeSet" % (elem,))
+        # Compute the rank in a single O(n) pass (no full sort) by counting
+        # the elements that come before `elem` in iteration order.
+        tkey = self._sortkey(key)
+        found = sum(1 for idx in set.__iter__(self)
+                    if self._sortkey(idx) < tkey)
+        if start != 0 or stop is not None:
+            start, stop = _normalized_index_bounds(len(self), start, stop)
+            if not start <= found < stop:
+                raise ValueError("%s is not in RangeSet" % (elem,))
+        return found
+
     def split(self, nbr):
         """
         Split the rangeset into nbr sub-rangesets (at most). Each
@@ -516,7 +571,7 @@ class RangeSet(set):
         less 1. Current rangeset remains unmodified. Returns an
         iterator.
 
-        >>> RangeSet("1-5").split(3) 
+        >>> RangeSet("1-5").split(3)
         RangeSet("1-2")
         RangeSet("3-4")
         RangeSet("foo5")
@@ -1066,6 +1121,39 @@ class RangeSetND(object):
         else:
             raise TypeError("%s indices must be integers" %
                             self.__class__.__name__)
+
+    @precond_fold()
+    def index(self, elem, start=0, stop=None):
+        """
+        Return the zero-based index of element in this RangeSetND, following
+        iteration order. This is the reverse operation of
+        :meth:`RangeSetND.__getitem__` and behaves like the ``index()`` method
+        of the ``list`` type.
+
+        The element is a vector (tuple) of indexes, given as integers or
+        strings (zero-padding is then significant). The optional `start` and
+        `stop` arguments restrict the search to the matching subsequence, and
+        may be negative (counted from the end).
+
+        :raises TypeError: the element is not a vector of indexes
+        :raises ValueError: the element is not present in the RangeSetND
+        """
+        # a bare string or scalar is not a valid index vector: iterating over
+        # a string would otherwise wrongly split it into per-character indexes
+        # (basestring catches both str and Python 2 unicode strings)
+        if isinstance(elem, basestring) or not hasattr(elem, '__iter__'):
+            raise TypeError("%s.index() argument must be a vector of indexes"
+                            % self.__class__.__name__)
+        target = tuple("%s" % e for e in elem)
+        for pos, ivec in enumerate(self._iter()):
+            if ivec == target:
+                if start != 0 or stop is not None:
+                    start, stop = _normalized_index_bounds(len(self),
+                                                           start, stop)
+                    if not start <= pos < stop:
+                        break
+                return pos
+        raise ValueError("%s is not in RangeSetND" % (elem,))
 
     @precond_fold()
     def contiguous(self):

--- a/tests/NodeSetTest.py
+++ b/tests/NodeSetTest.py
@@ -1087,6 +1087,66 @@ class NodeSetTest(unittest.TestCase):
         self.assertEqual(nodeset[34], "prune353")
         self.assertRaises(IndexError, nodeset.__getitem__, 35)
 
+    def test_index(self):
+        """test NodeSet.index()"""
+        nodeset = NodeSet("yeti[30,34-51,59-60]")
+        # index() is the reverse of __getitem__() for every node
+        for i, node in enumerate(nodeset):
+            self.assertEqual(nodeset.index(node), i)
+        self.assertEqual(nodeset.index("yeti30"), 0)
+        self.assertEqual(nodeset.index(u"yeti30"), 0)
+        self.assertEqual(nodeset.index("yeti34"), 1)
+        self.assertEqual(nodeset.index("yeti51"), 18)
+        self.assertEqual(nodeset.index("yeti60"), 20)
+        # missing node raises ValueError (like list.index())
+        self.assertRaises(ValueError, nodeset.index, "yeti31")
+        self.assertRaises(ValueError, nodeset.index, "foo1")
+        # a single node is required
+        self.assertRaises(ValueError, nodeset.index, "yeti[30,34]")
+
+        # several patterns, including unindexed nodes
+        nodeset = NodeSet("abc,cde[3-9,11],fgh")
+        for i, node in enumerate(nodeset):
+            self.assertEqual(nodeset.index(node), i)
+        self.assertEqual(nodeset.index("abc"), 0)
+        self.assertEqual(nodeset.index("cde3"), 1)
+        self.assertEqual(nodeset.index("cde11"), 8)
+        self.assertEqual(nodeset.index("fgh"), 9)
+
+        # zero-padding must match exactly
+        nodeset = NodeSet("prune[003-034,349-353/2]")
+        self.assertEqual(nodeset.index("prune003"), 0)
+        self.assertEqual(nodeset.index(u"prune003"), 0)
+        self.assertEqual(nodeset.index("prune034"), 31)
+        self.assertEqual(nodeset.index("prune349"), 32)
+        self.assertEqual(nodeset.index("prune353"), 34)
+        self.assertRaises(ValueError, nodeset.index, "prune3")
+        self.assertRaises(ValueError, nodeset.index, "prune35")
+
+        # optional start/end search window (list.index() semantics)
+        nodeset = NodeSet("node[0-9]")
+        self.assertEqual(nodeset.index("node5", 3), 5)
+        self.assertEqual(nodeset.index("node5", 5), 5)
+        self.assertRaises(ValueError, nodeset.index, "node5", 6)
+        self.assertEqual(nodeset.index("node8", -3), 8)
+        self.assertEqual(nodeset.index("node5", 0, 6), 5)
+        self.assertRaises(ValueError, nodeset.index, "node5", 0, 5)
+        self.assertRaises(ValueError, nodeset.index, "node9", 0, -1)
+
+    def test_nd_index(self):
+        """test NodeSet.index() (nD)"""
+        nodeset = NodeSet("da[30,34-51,59-60]p[1-2]")
+        for i, node in enumerate(nodeset):
+            self.assertEqual(nodeset.index(node), i)
+        self.assertEqual(nodeset.index("da30p1"), 0)
+        self.assertEqual(nodeset.index("da30p2"), 1)
+        self.assertEqual(nodeset.index("da34p1"), 2)
+        self.assertRaises(ValueError, nodeset.index, "da30p3")
+
+        nodeset = NodeSet("da[30,34-51,59-60]p[1-2],da[70-77]p2")
+        for i, node in enumerate(nodeset):
+            self.assertEqual(nodeset.index(node), i)
+
     def test_getslice(self):
         """test NodeSet getitem() with slice"""
         nodeset = NodeSet("yeti[30,34-51,59-60]")

--- a/tests/RangeSetNDTest.py
+++ b/tests/RangeSetNDTest.py
@@ -417,6 +417,34 @@ class RangeSetNDTest(unittest.TestCase):
         self.assertRaises(IndexError, rn1.__getitem__, -13)
         self.assertRaises(TypeError, rn1.__getitem__, "foo")
 
+    def test_index(self):
+        rn1 = RangeSetND([["10", "10-13"], ["0-3", "1-2"]])
+        # index() is the reverse of __getitem__()
+        for i in range(len(rn1)):
+            self.assertEqual(rn1.index(rn1[i]), i)
+        self.assertEqual(rn1.index(('0', '1')), 0)
+        self.assertEqual(rn1.index(('3', '2')), 7)
+        self.assertEqual(rn1.index(('10', '13')), 11)
+        self.assertEqual(rn1.index((u'10', u'13')), 11)
+        # integer vectors are also accepted
+        self.assertEqual(rn1.index((0, 1)), 0)
+        self.assertEqual(rn1.index((10, 13)), 11)
+        # missing vector raises ValueError (like list.index())
+        self.assertRaises(ValueError, rn1.index, ('10', '14'))
+        self.assertRaises(ValueError, rn1.index, ('5', '1'))
+        # a bare string or scalar is not a valid index vector: it must not be
+        # silently split into per-character/per-digit indexes
+        self.assertRaises(TypeError, rn1.index, "01")
+        self.assertRaises(TypeError, rn1.index, "0")
+        self.assertRaises(TypeError, rn1.index, 0)
+
+        # optional start/end search window (list.index() semantics)
+        self.assertEqual(rn1.index(('3', '2'), 7), 7)
+        self.assertRaises(ValueError, rn1.index, ('3', '2'), 8)
+        self.assertEqual(rn1.index(('10', '13'), -1), 11)
+        self.assertEqual(rn1.index(('10', '13'), 0, 12), 11)
+        self.assertRaises(ValueError, rn1.index, ('10', '13'), 0, -1)
+
     def test_getitem_slices(self):
         rn1 = RangeSetND([["10", "10-13"], ["0-3", "1-2"]])
         # slices

--- a/tests/RangeSetTest.py
+++ b/tests/RangeSetTest.py
@@ -455,6 +455,43 @@ class RangeSetTest(unittest.TestCase):
         self.assertEqual(r2[33], '106')
         self.assertRaises(TypeError, r2.__getitem__, "foo")
 
+    def testIndex(self):
+        """test RangeSet.index()"""
+        r1 = RangeSet("1-100,102,105-242,800")
+        # index() is the reverse of __getitem__()
+        for i in range(len(r1)):
+            self.assertEqual(r1.index(r1[i]), i)
+        # accept both string and integer arguments
+        self.assertEqual(r1.index('1'), 0)
+        self.assertEqual(r1.index(1), 0)
+        self.assertEqual(r1.index('102'), 100)
+        self.assertEqual(r1.index(105), 101)
+        self.assertEqual(r1.index('800'), 239)
+        self.assertEqual(r1.index(u'800'), 239)
+        # missing element raises ValueError (like list.index())
+        self.assertRaises(ValueError, r1.index, '101')
+        self.assertRaises(ValueError, r1.index, 101)
+        self.assertRaises(ValueError, r1.index, 900)
+
+        # zero-padding is significant
+        r2 = RangeSet("08-10")
+        self.assertEqual(r2.index('08'), 0)
+        self.assertEqual(r2.index('09'), 1)
+        self.assertEqual(r2.index('10'), 2)
+        self.assertEqual(r2.index(u'08'), 0)
+        self.assertRaises(ValueError, r2.index, '9')
+        self.assertRaises(ValueError, r2.index, 9)
+
+        # optional start/end search window (list.index() semantics)
+        r3 = RangeSet("0-9")
+        self.assertEqual(r3.index("5", 3), 5)
+        self.assertEqual(r3.index("5", 5), 5)
+        self.assertRaises(ValueError, r3.index, "5", 6)
+        self.assertEqual(r3.index("8", -3), 8)
+        self.assertEqual(r3.index("5", 0, 6), 5)
+        self.assertRaises(ValueError, r3.index, "5", 0, 5)
+        self.assertRaises(ValueError, r3.index, "9", 0, -1)
+
     def testGetSlice(self):
         """test RangeSet.__getitem__() with slice"""
         r0 = RangeSet("1-12")


### PR DESCRIPTION
Implements NodeSet.index() (and RangeSet/RangeSetND.index()). Alternative to #632.

Add an optimized index() method to NodeSet, RangeSet and RangeSetND that returns the position of an element following iteration order and raises ValueError when it is absent, like the index() method of the list type (including the optional start/stop search window for NodeSet).

The NodeSet implementation does not expand the whole set: it only sums the size of the patterns preceding the searched node and locates it within its own pattern, delegating the per-pattern lookup to RangeSet/RangeSetND.index().

This version, compares to #632 is more optimized, where this would make a performance difference for huge NodeSet length.

Closes #631.