### PR TITLE
RangeSet: accept unicode strings on Python 2

### DIFF
--- a/lib/ClusterShell/RangeSet.py
+++ b/lib/ClusterShell/RangeSet.py
@@ -129,7 +129,7 @@ class RangeSet(set):
         """
         set.__init__(self)
 
-        if pattern is not None and not isinstance(pattern, str):
+        if pattern is not None and not isinstance(pattern, basestring):
             pattern = ",".join("%s" % i for i in pattern)
 
         if isinstance(pattern, RangeSet):
@@ -138,7 +138,7 @@ class RangeSet(set):
             self._autostep = None
         self.autostep = autostep #: autostep threshold public instance attribute
 
-        if isinstance(pattern, str):
+        if isinstance(pattern, basestring):
             self._parse(pattern)
 
     def _parse(self, pattern):
@@ -809,7 +809,7 @@ class RangeSet(set):
 
     def update(self, iterable):
         """Add all indexes (as strings) from an iterable (such as a list)."""
-        assert not isinstance(iterable, str)
+        assert not isinstance(iterable, basestring)
         set.update(self, iterable)
 
     def updaten(self, rangesets):
@@ -839,7 +839,7 @@ class RangeSet(set):
         :param element: the element to add (integer or string)
         :param pad: zero padding length (integer); ignored if element is string
         """
-        if isinstance(element, str):
+        if isinstance(element, basestring):
             set.add(self, element)
         else:
             set.add(self, "%0*d" % (pad, int(element)))
@@ -856,7 +856,7 @@ class RangeSet(set):
         :raises KeyError: element is not contained in RangeSet
         :raises ValueError: element is not castable to integer
         """
-        if isinstance(element, str):
+        if isinstance(element, basestring):
             set.remove(self, element)
         else:
             set.remove(self, "%0*d" % (pad, int(element)))
@@ -874,7 +874,7 @@ class RangeSet(set):
         :param pad: zero padding length (integer); ignored if element is string
         """
         try:
-            if isinstance(element, str):
+            if isinstance(element, basestring):
                 set.discard(self, element)
             else:
                 set.discard(self, "%0*d" % (pad, int(element)))
@@ -934,7 +934,7 @@ class RangeSetND(object):
             return
         for rgvec in args:
             if rgvec:
-                if isinstance(rgvec[0], str):
+                if isinstance(rgvec[0], basestring):
                     self._veclist.append([RangeSet(rg, autostep=autostep) \
                                           for rg in rgvec])
                 elif isinstance(rgvec[0], RangeSet):

--- a/tests/RangeSetNDTest.py
+++ b/tests/RangeSetNDTest.py
@@ -42,6 +42,12 @@ class RangeSetNDTest(unittest.TestCase):
         self.assertEqual(str(rn), "11-60; 2\n0-10; 1-2\n")
         self.assertEqual(len(rn), 72)
 
+    def test_unicode(self):
+        # Python 2 compat: unicode string vectors parse like byte strings
+        self._testRS([[u"0-10"], [u"40-60"]], "0-10,40-60\n", 32)
+        self.assertEqual(RangeSetND([[u"0-3", u"4-10"]]),
+                         RangeSetND([["0-3", "4-10"]]))
+
     def test_nonzero(self):
         r0 = RangeSetND()
         if r0:

--- a/tests/RangeSetTest.py
+++ b/tests/RangeSetTest.py
@@ -29,6 +29,12 @@ class RangeSetTest(unittest.TestCase):
         self._testRS("1-3,4-6", "1-6", 6)
         self._testRS("1-3,4-6,7-10", "1-10", 10)
 
+    def testParseUnicode(self):
+        """test RangeSet unicode pattern parsing"""
+        # Python 2 compat
+        self.assertEqual(RangeSet(u"01-10"), RangeSet("01-10"))
+        self.assertEqual(len(RangeSet(u"0001-0100")), 100)
+
     def testStepSimple(self):
         """test RangeSet simple step usages"""
         self._testRS("0-4/2", "0-4/2", 3)
@@ -644,6 +650,11 @@ class RangeSetTest(unittest.TestCase):
         r1.padding = 4  # 1.8-1.9 compat: adjust padding of the whole set
         self.assertEqual(len(r1), 241)
         self.assertEqual(str(r1), "0001-0100,0102,0105-0242,0800-0801")
+        # unicode element accepted like byte str (Python 2 compat)
+        ra, rb = RangeSet("1-10"), RangeSet("1-10")
+        ra.add(u"011")
+        rb.add("011")
+        self.assertEqual(ra, rb)
 
     def testUpdate(self):
         """test RangeSet.update()"""
@@ -695,6 +706,13 @@ class RangeSetTest(unittest.TestCase):
         self.assertRaises(KeyError, r1.remove, "101")
         r1.remove("106")
         self.assertRaises(KeyError, r1.remove, "foo")
+        # unicode element accepted like byte str (Python 2 compat)
+        ra, rb = RangeSet("1-10"), RangeSet("1-10")
+        ra.remove(u"5")
+        rb.remove("5")
+        self.assertEqual(ra, rb)
+        self.assertRaises(KeyError, ra.remove, u"5")
+        self.assertRaises(KeyError, ra.remove, u"foo")
 
     def testDiscard(self):
         """test RangeSet.discard()"""
@@ -708,6 +726,13 @@ class RangeSetTest(unittest.TestCase):
         self.assertEqual(len(r1), 238)
         self.assertEqual(str(r1), "1-99,102,106-242,800")
         r1.discard("foo")
+        # unicode element accepted like byte str (Python 2 compat)
+        ra, rb = RangeSet("1-10"), RangeSet("1-10")
+        ra.discard(u"5")
+        rb.discard("5")
+        ra.discard(u"bar")  # non-numeric unicode: no exception
+        self.assertEqual(ra, rb)
+        self.assertEqual(str(ra), "1-4,6-10")
 
     def testClear(self):
         """test RangeSet.clear()"""


### PR DESCRIPTION
On Python 2, `isinstance(x, str)` excludes unicode (`str == bytes`), so unicode
arguments were mishandled — a unicode pattern gave an empty RangeSet, and a
unicode vector raised ValueError in RangeSetND:

    # Python 2.7
    >>> RangeSet("01-10")                 # 01-10
    >>> len(RangeSet(u"01-10"))           # 0  (expected 10)
    >>> RangeSetND([[u"0-3", u"4-10"]])   # ValueError

Fix: check `basestring` instead of `str` throughout `RangeSet` and `RangeSetND`
(constructors plus the add/remove/discard/update element paths). No-op on
Python 3.