### PR TITLE
setup: clean up wheel packaging metadata (#634)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[install]
-optimize = 1

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(name='ClusterShell',
       keywords=['clustershell', 'clush', 'clubak', 'nodeset'],
       description='ClusterShell library and tools',
       long_description=open('doc/txt/clustershell.rst').read(),
+      long_description_content_type='text/x-rst',
       classifiers=[
           "Development Status :: 5 - Production/Stable",
           "Environment :: Console",


### PR DESCRIPTION
Two small packaging fixes so ClusterShell can ship a clean pure-Python wheel
on PyPI:

- Remove `setup.cfg` — its only content was `[install] optimize = 1` (added in
  2008), which baked interpreter-specific `.opt-1.pyc` files into the built
  wheel (37 in the 1.9.3 `py3-none-any` wheel). Those don't belong in a
  universal wheel, and pip recompiles bytecode on install anyway.
- Add `long_description_content_type='text/x-rst'` to `setup()` — finishes the
  `twine check` cleanup begun in #577 (which fixed the RST error but left the
  `long_description_content_type missing` warning).

Verified: `python -m build` → `py3-none-any` wheel with 0 stray `.pyc`,
`twine check` clean; builds/installs under py2.7 + py3.6 on EL7 and py3.13.
