### PR TITLE
Add deprecation warnings for set_verbosity() and topology [Main] section

### DIFF
--- a/lib/ClusterShell/CLI/Clubak.py
+++ b/lib/ClusterShell/CLI/Clubak.py
@@ -31,7 +31,7 @@ import sys
 
 from ClusterShell.Defaults import DEFAULTS
 from ClusterShell.MsgTree import MsgTree, MODE_DEFER, MODE_TRACE
-from ClusterShell.NodeSet import NodeSet, NodeSetParseError, std_group_resolver
+from ClusterShell.NodeSet import NodeSet, NodeSetParseError
 from ClusterShell.NodeSet import set_std_group_resolver_config
 
 from ClusterShell.CLI.Display import Display, THREE_CHOICES
@@ -172,7 +172,6 @@ def clubak():
         return
 
     if options.debug:
-        std_group_resolver().set_verbosity(1)
         print("clubak: line_mode=%s gather=%s tree_depth=%d"
               % (bool(options.line_mode), bool(disp.gather), tree._depth()),
               file=sys.stderr)

--- a/lib/ClusterShell/CLI/Clush.py
+++ b/lib/ClusterShell/CLI/Clush.py
@@ -952,8 +952,6 @@ def main():
     # Do we have nodes group?
     task = task_self()
     task.set_info("debug", config.verbosity >= VERB_DEBUG)
-    if config.verbosity == VERB_DEBUG:
-        std_group_resolver().set_verbosity(1)
     if options.nodes_all:
         all_nodeset = NodeSet.fromall()
         display.vprint(VERB_DEBUG, "Adding nodes from option -a: %s" % \

--- a/lib/ClusterShell/NodeUtils.py
+++ b/lib/ClusterShell/NodeUtils.py
@@ -42,6 +42,7 @@ import logging
 import os
 import shlex
 import time
+import warnings
 
 from string import Template
 from subprocess import Popen, PIPE
@@ -463,6 +464,8 @@ class GroupResolver(object):
     @init
     def set_verbosity(self, value):
         """Set debugging verbosity value (DEPRECATED: use logging.DEBUG)."""
+        warnings.warn("set_verbosity() is deprecated; use logging instead",
+                      DeprecationWarning, stacklevel=2)
         for source in self._sources.values():
             source.verbosity = value
 

--- a/lib/ClusterShell/Topology.py
+++ b/lib/ClusterShell/Topology.py
@@ -43,6 +43,7 @@ except ImportError:
     import ConfigParser as configparser
 
 import logging
+import warnings
 
 from ClusterShell.NodeSet import NodeSet
 
@@ -449,6 +450,8 @@ class TopologyParser(configparser.ConfigParser):
                 self._topology = self.items("routes")
             else:
                 # compat routes section [deprecated since v1.7]
+                warnings.warn("topology: [Main] section is deprecated since "
+                              "v1.7, use [routes] instead", DeprecationWarning)
                 self._topology = self.items("Main")
         except configparser.Error:
             raise TopologyError(

--- a/tests/CLIClushTest.py
+++ b/tests/CLIClushTest.py
@@ -949,7 +949,7 @@ class CLIClushTest_E_Topology(unittest.TestCase):
 
     def setUp(self):
         self.topofile = make_temp_file(dedent("""
-                        [Main]
+                        [routes]
                         %s: localhost
                         localhost: remote-node"""% HOSTNAME).encode())
 

--- a/tests/TreeTaskTest.py
+++ b/tests/TreeTaskTest.py
@@ -28,7 +28,7 @@ class TreeTaskTest(unittest.TestCase):
         """test task shell auto tree"""
         # initialize a dummy topology.conf file
         topofile = make_temp_file(dedent("""
-                        [Main]
+                        [routes]
                         %s: dummy-gw
                         dummy-gw: dummy-node"""% HOSTNAME).encode())
         task = task_self()
@@ -53,7 +53,7 @@ class TreeTaskTest(unittest.TestCase):
         """test task shell auto tree [TopologyError]"""
         # initialize an erroneous topology.conf file
         topofile = make_temp_file(dedent("""
-                        [Main]
+                        [routes]
                         %s: dummy-gw
                         dummy-gw: dummy-gw"""% HOSTNAME).encode())
         task = task_self()

--- a/tests/TreeTopologyTest.py
+++ b/tests/TreeTopologyTest.py
@@ -4,6 +4,7 @@
 """Unit test for Topology"""
 
 import unittest
+import warnings
 from tempfile import NamedTemporaryFile
 from textwrap import dedent
 
@@ -249,7 +250,12 @@ class TopologyTest(unittest.TestCase):
             tmpfile.write(b'nodes[0-1]: nodes[2-5]\n')
             tmpfile.write(b'nodes[4-5]: nodes[6-9]\n')
             tmpfile.flush()
-            parser = TopologyParser(tmpfile.name)
+            # NOTE: use self.assertWarns() once Python 2 is dropped (py3.2+)
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                parser = TopologyParser(tmpfile.name)
+                self.assertEqual(len(w), 1)
+                self.assertTrue(issubclass(w[0].category, DeprecationWarning))
 
             parser.tree('admin')
             ns_all = NodeSet('admin,nodes[0-9]')


### PR DESCRIPTION
Add runtime deprecation warnings for two long-deprecated surfaces:

- `GroupResolver.set_verbosity()` — documented deprecated for years but never
  warned at runtime. The `GroupSource.verbosity` value it set is no longer read,
  so the clush/clubak `-d` calls to it were dead no-ops and are removed.
- the pre-v1.7 topology.conf `[Main]` section — silent compat fallback now warns
  (use `[routes]`); stray topology fixtures in the test suite moved
  `[Main]` → `[routes]`.

`DeprecationWarning` is silent for normal CLI users (default filters), visible
only under `-W` or test runners, and never fails the build. The remaining #226
items (constant/class aliases) need py3-only `__getattr__` and are deferred to 1.11.

See #226
