### PR TITLE
Task: only terminate Task once (#110)

### DIFF
--- a/lib/ClusterShell/Task.py
+++ b/lib/ClusterShell/Task.py
@@ -962,6 +962,11 @@ class Task(object):
         Abort completion subroutine.
         """
         assert self._quit == True
+
+        # already fully terminated by a prior abort pass (#110)
+        if self._engine is None:
+            return
+
         self._terminated = True
 
         if kill:

--- a/tests/TLib.py
+++ b/tests/TLib.py
@@ -2,6 +2,7 @@
 Unit test library
 """
 
+import logging
 import os
 import socket
 import sys
@@ -95,6 +96,9 @@ def CLI_main(test, main, args, stdin, expected_stdout, expected_rc=0,
     saved_stdin = sys.stdin
     saved_stdout = sys.stdout
     saved_stderr = sys.stderr
+    # a CLI -d run calls logging.basicConfig(); snapshot root logging to restore it
+    saved_log_handlers = logging.root.handlers[:]
+    saved_log_level = logging.root.level
 
     # Capture standard streams
 
@@ -123,6 +127,12 @@ def CLI_main(test, main, args, stdin, expected_stdout, expected_rc=0,
     finally:
         sys.stdout = saved_stdout
         sys.stderr = saved_stderr
+        # undo logging config a CLI -d run leaked (handler bound to closed stderr)
+        for handler in logging.root.handlers:
+            if handler not in saved_log_handlers:
+                handler.close()
+        logging.root.handlers[:] = saved_log_handlers
+        logging.root.setLevel(saved_log_level)
         # close temporary file if we used one for stdin
         if saved_stdin != sys.stdin:
             sys.stdin.close()

--- a/tests/TaskThreadJoinTest.py
+++ b/tests/TaskThreadJoinTest.py
@@ -6,8 +6,10 @@ Unit test for ClusterShell task's join feature in multithreaded
 environments
 """
 
+import sys
 import time
 import unittest
+from io import StringIO
 
 from ClusterShell.Task import *
 from ClusterShell.Event import EventHandler
@@ -128,3 +130,36 @@ class TaskThreadJoinTest(unittest.TestCase):
 
         task_wait()
         task.resume()
+
+    def testThreadTaskTerminateOnceOnRunningAbort(self):
+        """test task_cleanup() terminates a running task only once (#110)"""
+
+        tasks = []
+        for i in range(1, 5):
+            task = Task()
+            task.shell("sleep %d" % i)
+            tasks.append(task)
+
+        task_wait()
+        last = tasks[-1]
+        last.resume()
+        # make sure the last task is actually inside engine.run() before abort
+        deadline = time.time() + 5
+        while not last.running() and time.time() < deadline:
+            time.sleep(0.01)
+        self.assertTrue(last.running())
+
+        # a double _terminate() raises AttributeError on a Task thread; capture
+        # stderr to detect the spurious traceback (#110)
+        saved_stderr = sys.stderr
+        sys.stderr = StringIO()
+        try:
+            task_cleanup()
+            for task in tasks:
+                task.thread.join()
+            captured = sys.stderr.getvalue()
+        finally:
+            sys.stderr = saved_stderr
+
+        self.assertNotIn("AttributeError", captured)
+        self.assertNotIn("Traceback", captured)


### PR DESCRIPTION
Aborting a running task with `kill=True` (e.g. via `task_cleanup()`) made
`_terminate()` run twice — from `_resume()`'s `EngineAbortException` handler
(which sets `self._engine = None`) and again from `_thread_start()` — raising
`AttributeError: 'NoneType' object has no attribute 'clear'` on the task thread.

- Fix: return early from `_terminate()` when the engine is already cleared.
- Add a regression test forcing the running-abort race.

The regression test exposed a pre-existing harness wart, fixed in a separate
commit: a `-d`/`--debug` CLI run calls `logging.basicConfig()`, binding a root
handler to `CLI_main`'s captured stderr that is then closed. A later test's
daemon-thread debug log then writes to the closed stream, leaking a traceback
into its captured output — making `testThreadTaskTerminateOnceOnRunningAbort`
flaky in some module subsets. `CLI_main` now snapshots and restores the root
logger's handlers and level around each run.

Closes #110