### PR TITLE
logging: add NullHandler to top-level library logger (#641)

### DIFF
--- a/doc/sphinx/guide/index.rst
+++ b/doc/sphinx/guide/index.rst
@@ -2,11 +2,11 @@ Programming Guide
 =================
 
 This part provides programming information for using ClusterShell in
-Python applications. It is divided into two sections: node sets handling and
-cluster task management, in that order, because managing cluster tasks
-requires some knowledge of how to deal with node sets. Each section also
-describes the conceptual structures of ClusterShell and provides examples of
-how to use them.
+Python applications. It starts with node sets handling, then cluster task
+management, in that order, because managing cluster tasks requires some
+knowledge of how to deal with node sets. These sections also describe the
+conceptual structures of ClusterShell and provide examples of how to use
+them. A separate section explains how the library logs messages.
 
 This part is intended for intermediate and advanced programmers who are
 familiar with Python programming and basic concepts of high-performance
@@ -18,4 +18,5 @@ computing (HPC).
     nodesets
     rangesets
     taskmgnt
+    logging
     examples

--- a/doc/sphinx/guide/logging.rst
+++ b/doc/sphinx/guide/logging.rst
@@ -1,0 +1,64 @@
+.. _library-logging:
+
+Library logging
+===============
+
+.. highlight:: python
+
+Logger namespace
+----------------
+
+ClusterShell uses the standard Python ``logging`` module. Each module logs
+through a logger named after itself, below the top-level ``ClusterShell``
+logger, for example ``ClusterShell.NodeUtils``, ``ClusterShell.Task`` or
+``ClusterShell.Worker.Tree``.
+
+Following the `Logging HOWTO recommendation for libraries
+<https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library>`_,
+ClusterShell never configures logging on behalf of your application: it only
+adds a ``NullHandler`` to its top-level logger. Nothing is logged anywhere
+until your application configures logging.
+
+.. warning:: Since version 1.11, an application that does not configure
+   logging no longer sees ClusterShell warnings and errors on standard error.
+   Such messages were previously printed by the ``logging`` module handler of
+   last resort. Configure logging as shown below to get them back.
+
+.. _library-logging-enabling:
+
+Enabling ClusterShell messages
+------------------------------
+
+The simplest way is to configure logging globally in your application::
+
+    import logging
+
+    logging.basicConfig(level=logging.WARNING)
+
+To enable ClusterShell messages only, and leave the logging configuration of
+the rest of your application untouched, add a handler to the ``ClusterShell``
+logger instead::
+
+    import logging
+
+    handler = logging.StreamHandler()  # stderr
+    handler.setFormatter(logging.Formatter('%(name)s: %(levelname)s: '
+                                           '%(message)s'))
+
+    logger = logging.getLogger('ClusterShell')
+    logger.addHandler(handler)
+    logger.setLevel(logging.WARNING)
+
+The same applies to a single module: use ``ClusterShell.NodeUtils`` to get
+node group resolution messages only.
+
+.. note:: Most ClusterShell log records are ``DEBUG`` ones written to
+   troubleshoot the library itself. They are verbose and contain object
+   representations and engine internals. Use ``WARNING`` and above to only get
+   messages that report an actual problem.
+
+The command-line tools configure logging themselves, so this does not affect
+them: see the ``-d`` option of :ref:`clush <clush-tool>`,
+:ref:`nodeset <nodeset-tool>` and :ref:`cluset <cluset-tool>`. In Tree mode,
+gateways write their own log file, as described in
+:ref:`clush-tree-debug`.

--- a/doc/sphinx/tools/clush.rst
+++ b/doc/sphinx/tools/clush.rst
@@ -313,6 +313,8 @@ variable::
 .. note:: It is highly recommended to have the same Python interpreter
    installed on all gateways and the root node.
 
+.. _clush-tree-debug:
+
 Debugging Tree mode
 """""""""""""""""""
 

--- a/lib/ClusterShell/Gateway.py
+++ b/lib/ClusterShell/Gateway.py
@@ -326,13 +326,15 @@ def gateway_main():
     logdir = os.path.expanduser(os.environ.get('CLUSTERSHELL_GW_LOG_DIR',
                                                '/tmp'))
     loglevel = os.environ.get('CLUSTERSHELL_GW_LOG_LEVEL', 'INFO')
+    log_level = getattr(logging, loglevel.upper(), logging.INFO)
+    log_fmt = '%(asctime)s %(name)s %(levelname)s %(message)s'
+
     try:
-        log_level = getattr(logging, loglevel.upper(), logging.INFO)
-        log_fmt = '%(asctime)s %(name)s %(levelname)s %(message)s'
         logging.basicConfig(level=log_level, format=log_fmt,
                             filename=os.path.join(logdir, "%s.gw.log" % host))
     except (IOError, OSError):
-        pass  # logging failure is not fatal
+        # log file not writable: fall back to stderr, relayed to the root node
+        logging.basicConfig(level=log_level, format=log_fmt)
 
     logger = logging.getLogger(__name__)
     sys.excepthook = gateway_excepthook

--- a/lib/ClusterShell/__init__.py
+++ b/lib/ClusterShell/__init__.py
@@ -34,8 +34,13 @@ Please see first:
   - ClusterShell.Task
 """
 
+import logging
+
 __version__ = '1.10.1'
 __version_info__ = tuple([ int(_n) for _n in __version__.split('.')])
 __date__    = '2026/07/16'
 __author__  = 'Stephane Thiell'
 __url__     = 'https://clustershell.readthedocs.io/'
+
+# stay quiet by default as a library, per the Python Logging HOWTO
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/tests/LoggingTest.py
+++ b/tests/LoggingTest.py
@@ -1,0 +1,49 @@
+# ClusterShell test suite
+# Written by S. Thiell
+
+"""Unit test for ClusterShell library logging"""
+
+import logging
+import sys
+import unittest
+
+from io import StringIO
+
+import ClusterShell  # importing the package installs the NullHandler
+
+
+class LibraryLoggingTest(unittest.TestCase):
+    """Test the library logging posture (Python Logging HOWTO)"""
+
+    def setUp(self):
+        """save root logging state, other tests may have configured it"""
+        self.saved_handlers = logging.root.handlers[:]
+        self.saved_level = logging.root.level
+        self.saved_stderr = sys.stderr
+        logging.root.handlers[:] = []
+        logging.root.setLevel(logging.WARNING)
+        sys.stderr = StringIO()
+
+    def tearDown(self):
+        sys.stderr = self.saved_stderr
+        logging.root.handlers[:] = self.saved_handlers
+        logging.root.setLevel(self.saved_level)
+
+    def test_null_handler(self):
+        """test NullHandler on the top-level ClusterShell logger"""
+        handlers = logging.getLogger('ClusterShell').handlers
+        self.assertTrue(any(isinstance(handler, logging.NullHandler)
+                            for handler in handlers))
+
+    def test_quiet_when_unconfigured(self):
+        """test library logging is quiet when the application is not set up"""
+        logging.getLogger('ClusterShell.Test').warning('should not be seen')
+        self.assertEqual(sys.stderr.getvalue(), '')
+
+    def test_propagate_when_configured(self):
+        """test library records still reach application handlers"""
+        stream = StringIO()
+        logging.root.addHandler(logging.StreamHandler(stream))
+
+        logging.getLogger('ClusterShell.Test').warning('should be seen')
+        self.assertEqual(stream.getvalue(), 'should be seen\n')


### PR DESCRIPTION
Follow the [Logging HOWTO guidance for libraries](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library): add a `NullHandler` to the top-level `ClusterShell` logger.

- Without it, an application embedding the library without configuring logging gets ClusterShell's WARNING+ records raw on stderr via `logging.lastResort` (Python 3.2+), or a "No handlers could be found" message (Python 2.7).
- All library emission sites use `getLogger(__name__)` under the `ClusterShell` namespace, so one handler covers them all.
- No CLI change: `clush -d` debug output is unchanged (records still propagate to the root handler); normal runs stay quiet; gateway file logging unaffected.
- Behavior note: embedders that relied on the implicit `lastResort` output must now configure logging to see ClusterShell messages — the standard opt-in library posture.
- `logging.NullHandler` is available since Python 2.7.

Documented in a new *Library logging* section of the Programming Guide (logger namespace, the `NullHandler` posture, how to enable messages, and a warning about the behavior change), as asked in review.

The second commit covers the one place where `lastResort` was doing real work: a gateway relays its stderr to the root node through the propagation channel, so `Gateway failure:` messages stayed visible even when `CLUSTERSHELL_GW_LOG_DIR` is not writable. With the `NullHandler` alone they go silent, leaving only exit code 1 — so `gateway_main()` now falls back to stderr logging when the log file cannot be opened. Checked by hand with an unwritable log dir; the writable case is unchanged.

Closes #641
See #687
