### PR TITLE
Documentation: post-1.10 coverage cleanup

### DIFF
--- a/doc/man/man1/clubak.1
+++ b/doc/man/man1/clubak.1
@@ -59,11 +59,20 @@ show \fBclubak\fP version number and exit
 gather nodes with same output (\-c is provided for \fBdshbak\fP(1)
 compatibility)
 .TP
+.B  \-B
+same as \-b; accepted for compatibility with \fBclush\fP(1), where \-B also gathers standard error
+.TP
+.B  \-v\fP,\fB  \-\-verbose
+be verbose, print informative messages; also echo each input line to standard output prefixed by \fBINPUT\fP
+.TP
 .B  \-d\fP,\fB  \-\-debug
 output more messages for debugging purpose
 .TP
 .B  \-L
 disable header block and order output by nodes
+.TP
+.B  \-N
+disable labeling of command line
 .TP
 .B  \-r\fP,\fB  \-\-regroup
 fold nodeset using node groups
@@ -88,6 +97,9 @@ faster but memory hungry mode (preload all messages per node)
 .TP
 .B  \-T\fP,\fB  \-\-tree
 message tree trace mode; switch to enable \fBClusterShell.MsgTree\fP trace mode, all keys/nodes being kept for each message element of the tree, thus allowing special output gathering
+.TP
+.BI \-\-interpret\-keys\fB= INTERPRET_KEYS
+whether to interpret keys (the field before the separator on each input line) as node sets. \fIINTERPRET_KEYS\fP is \fBnever\fP, \fBalways\fP or \fBauto\fP (the default). With \fBnever\fP, each key is kept as a plain string; with \fBalways\fP, every key must be a valid node set; with \fBauto\fP, keys are interpreted as node sets, but if any key cannot be parsed, \fBclubak\fP silently switches to treating all keys as plain strings.
 .TP
 .BI \-\-color\fB= WHENCOLOR
 \fBclush\fP can use NO_COLOR, CLICOLOR and CLICOLOR_FORCE environment variables. \fB\-\-color\fP command line option always takes precedence over environment variables. NO_COLOR takes precedence over CLICOLOR_FORCE which takes precedence over CLICOLOR. \fB\-\-color\fP tells whether to use ANSI colors to surround node or nodeset prefix/header with escape sequences to display them in color on the terminal. \fIWHENCOLOR\fP is \fBnever\fP, \fBalways\fP or \fBauto\fP (which use color if standard output refers to a terminal). Color is set to [34m (blue foreground text) and cannot be modified.

--- a/doc/man/man1/cluset.1
+++ b/doc/man/man1/cluset.1
@@ -91,7 +91,7 @@ fold nodes using node groups (see \-s \fIGROUPSOURCE\fP)
 .BI \-\-index\fB= NODE
 output the index of NODE in the nodeset (reverse of \-I/\-\-slice)
 .TP
-.B  \-\-groupsources
+.B  \-\-list\-sources\fP,\fB  \-\-groupsources
 list all active group sources (see \fBgroups.conf\fP(5))
 .UNINDENT
 .TP
@@ -264,7 +264,7 @@ Any wildcard mask found is matched against all nodes from the group source (see 
 This can be especially useful for server farms, or when cluster node names differ.
 .INDENT 0.0
 .TP
-.B Say that your group configuration is set to return the following “all nodes”:
+.B Say that your group configuration is set to return the following \(dqall nodes\(dq:
 .INDENT 7.0
 .TP
 .B $ cluset \-f \-a

--- a/doc/man/man1/nodeset.1
+++ b/doc/man/man1/nodeset.1
@@ -91,7 +91,7 @@ fold nodes using node groups (see \-s \fIGROUPSOURCE\fP)
 .BI \-\-index\fB= NODE
 output the index of NODE in the nodeset (reverse of \-I/\-\-slice)
 .TP
-.B  \-\-groupsources
+.B  \-\-list\-sources\fP,\fB  \-\-groupsources
 list all active group sources (see \fBgroups.conf\fP(5))
 .UNINDENT
 .TP
@@ -264,7 +264,7 @@ Any wildcard mask found is matched against all nodes from the group source (see 
 This can be especially useful for server farms, or when cluster node names differ.
 .INDENT 0.0
 .TP
-.B Say that your group configuration is set to return the following “all nodes”:
+.B Say that your group configuration is set to return the following \(dqall nodes\(dq:
 .INDENT 7.0
 .TP
 .B $ nodeset \-f \-a

--- a/doc/man/man5/groups.conf.5
+++ b/doc/man/man5/groups.conf.5
@@ -91,6 +91,8 @@ default group source). The variable \fI$CFGDIR\fP is replaced by the path of the
 highest priority configuration directory found (where groups.conf resides).
 The default confdir value enables both system\-wide and any installed user
 configuration (thanks to \fI$CFGDIR\fP). Duplicate directory paths are ignored.
+\fBgroupsdir\fP is accepted as an alias for \fBconfdir\fP and takes precedence
+when both are defined.
 .TP
 .B autodir
 Optional list of directories where the ClusterShell library should look for
@@ -155,7 +157,8 @@ Default is 3600 seconds. This is useful only for daemons using nodegroups.
 .sp
 When the library executes a group source external shell command, the current
 working directory is previously set to the corresponding confdir. This
-allows the use of relative paths for third party files in the command.
+allows the use of relative paths for third party files in the command. The
+command\(aqs standard input is connected to \fI/dev/null\fP\&.
 .sp
 In addition to context\-dependent $GROUP and $NODE variables described above, the
 two following variables are always available and also replaced before executing

--- a/doc/sphinx/api/EnginePort.rst
+++ b/doc/sphinx/api/EnginePort.rst
@@ -1,0 +1,10 @@
+EnginePort
+----------
+
+.. py:currentmodule:: ClusterShell.Worker.EngineClient
+
+.. autoclass:: EnginePort
+    :members:
+    :inherited-members:
+    :special-members:
+    :exclude-members: invalidate, is_valid, set_nextfire

--- a/doc/sphinx/api/MsgTree.rst
+++ b/doc/sphinx/api/MsgTree.rst
@@ -3,6 +3,9 @@ MsgTree
 
 .. automodule:: ClusterShell.MsgTree
 .. py:currentmodule:: ClusterShell.MsgTree
+.. autoclass:: MsgTreeElem
+    :members:
+    :special-members:
 .. autoclass:: MsgTree
     :members:
     :special-members:

--- a/doc/sphinx/api/NodeSet.rst
+++ b/doc/sphinx/api/NodeSet.rst
@@ -13,3 +13,4 @@ NodeSet
 .. autofunction:: grouplist
 .. autofunction:: std_group_resolver
 .. autofunction:: set_std_group_resolver
+.. autofunction:: set_std_group_resolver_config

--- a/doc/sphinx/api/NodeUtils.rst
+++ b/doc/sphinx/api/NodeUtils.rst
@@ -6,6 +6,10 @@ NodeUtils
 .. autoclass:: GroupSource
     :members:
     :special-members:
+.. autoclass:: UpcallGroupSource
+    :members:
+    :special-members:
+    :exclude-members: __init__
 .. autoclass:: GroupResolver
     :members:
     :special-members:

--- a/doc/sphinx/api/index.rst
+++ b/doc/sphinx/api/index.rst
@@ -14,4 +14,5 @@ ClusterShell public API autodoc.
     Defaults
     Event
     EngineTimer
+    EnginePort
     workers/index

--- a/doc/sphinx/config.rst
+++ b/doc/sphinx/config.rst
@@ -274,7 +274,8 @@ The *groups.conf* files are parsed with Python's `ConfigParser`_:
     the path of the highest priority configuration directory found (where
     *groups.conf* resides). The default *confdir* value enables both
     system-wide and any installed user configuration (thanks to `$CFGDIR`).
-    Duplicate directory paths are ignored.
+    Duplicate directory paths are ignored. The key *groupsdir* is accepted as
+    an alias for *confdir*; if both are defined, *groupsdir* takes precedence.
   * *autodir* defines an optional list of directories where the ClusterShell
     library should look for **.yaml** files that define in-file group
     dictionaries. No need to call external commands for these files, they are
@@ -458,6 +459,9 @@ before executing shell commands:
 * *$CFGDIR* is replaced by *groups.conf* base directory path
 * *$SOURCE* is replaced by current source name (see an usage example just
   below)
+
+Upcall commands are executed with their standard input connected to
+``/dev/null``, so they must not expect any input on stdin.
 
 .. _group-external-caching:
 
@@ -774,6 +778,34 @@ Example of use with :ref:`nodeset-tool` on a cluster managed with Ansible::
 
 .. highlight:: text
 
+.. _topology-config:
+
+Tree topology
+-------------
+
+The optional *topology.conf* file defines the propagation routes used by
+ClusterShell's :ref:`tree execution mode <clush-tree>` to reach target nodes
+through gateway nodes. It is loaded from the same configuration directories as
+the other ClusterShell configuration files, the system-wide default being::
+
+    /etc/clustershell/topology.conf
+
+.. highlight:: ini
+
+Routes are declared under a ``[routes]`` section, for example::
+
+    [routes]
+    rio0: rio[10-13]
+    rio[10-11]: rio[100-240]
+    rio[12-13]: rio[300-440]
+
+.. highlight:: text
+
+An example file is provided with ClusterShell as *topology.conf.example*. See
+:ref:`clush-tree` for a full description of tree mode, including how routes are
+turned into a propagation tree and the related command line options (such as
+``--topology``).
+
 .. _defaults-config:
 
 Library Defaults
@@ -804,6 +836,105 @@ valid, it will used instead. In such case, the following configuration file
 will be tried first for ClusterShell defaults::
 
     $CLUSTERSHELL_CFGDIR/defaults.conf
+
+Settings
+^^^^^^^^
+
+Library defaults are organized in sections, each of them covering a
+particular ClusterShell subsystem. The following tables describe the
+available settings, grouped by section.
+
+The ``[task.default]`` section defines Task worker defaults.
+
++--------------------+----------------------------------------------------+
+| Key                | Value                                              |
++====================+====================================================+
+| stderr             | Whether to store stderr separately from stdout     |
+|                    | (default: no).                                     |
++--------------------+----------------------------------------------------+
+| stdin              | Whether to keep the command's standard input open  |
+|                    | for writing (e.g. via ``Worker.write()``); if      |
+|                    | disabled, EOF is sent at startup so commands that  |
+|                    | read from stdin do not block (default: yes).       |
++--------------------+----------------------------------------------------+
+| stdout_msgtree     | Whether to gather stdout in a message tree, as     |
+|                    | required to display gathered output, eg. with      |
+|                    | ``clush -b`` (default: yes).                       |
++--------------------+----------------------------------------------------+
+| stderr_msgtree     | Whether to gather stderr in a message tree         |
+|                    | (default: yes).                                    |
++--------------------+----------------------------------------------------+
+| engine             | Event engine backend: *auto*, *epoll*, *poll* or   |
+|                    | *select* (default: *auto*). With *auto*, the best  |
+|                    | available backend is selected: *epoll* first, then |
+|                    | *poll*, then *select*. Overriding the default is   |
+|                    | rarely needed and mostly useful for debugging.     |
++--------------------+----------------------------------------------------+
+| port_qlimit        | Accepted here only for 1.8 compatibility; a        |
+|                    | non-default value in the ``[engine]`` section      |
+|                    | takes precedence.                                  |
++--------------------+----------------------------------------------------+
+| auto_tree          | Whether to automatically enable                    |
+|                    | :ref:`tree mode <clush-tree>` when a               |
+|                    | *topology.conf* file is found (default: yes).      |
++--------------------+----------------------------------------------------+
+| local_workername   | Name of the worker module used for local           |
+|                    | execution (default: *exec*).                       |
++--------------------+----------------------------------------------------+
+| distant_workername | Name of the worker module used for remote          |
+|                    | execution (default: *ssh*; see the *rsh* use       |
+|                    | case below).                                       |
++--------------------+----------------------------------------------------+
+
+The ``[task.info]`` section defines Task runtime defaults.
+
++--------------------+----------------------------------------------------+
+| Key                | Value                                              |
++====================+====================================================+
+| debug              | Whether to enable library debugging output         |
+|                    | (default: no).                                     |
++--------------------+----------------------------------------------------+
+| fanout             | Size of the sliding window of connectors (eg. max  |
+|                    | number of *ssh(1)* processes allowed to run at the |
+|                    | same time) (default: 64).                          |
++--------------------+----------------------------------------------------+
+| grooming_delay     | Delay in seconds during which gateways aggregate   |
+|                    | identical output lines and return codes before     |
+|                    | sending them back in batch (tree mode)             |
+|                    | (default: 0.25).                                   |
++--------------------+----------------------------------------------------+
+| connect_timeout    | Timeout in seconds to allow a connection to        |
+|                    | establish; if set to 0, no timeout occurs          |
+|                    | (default: 10).                                     |
++--------------------+----------------------------------------------------+
+| command_timeout    | Timeout in seconds to allow a command to           |
+|                    | complete; if set to 0, no timeout occurs           |
+|                    | (default: 0).                                      |
++--------------------+----------------------------------------------------+
+
+The ``[engine]`` section defines event engine defaults.
+
++--------------------+----------------------------------------------------+
+| Key                | Value                                              |
++====================+====================================================+
+| port_qlimit        | Maximum number of messages that can be queued on   |
+|                    | an engine port, used for inter-thread task         |
+|                    | messaging (default: 100). This is the preferred    |
+|                    | section for this key; a non-default value here     |
+|                    | takes precedence over ``[task.default]`` (kept     |
+|                    | for 1.8 compatibility).                            |
++--------------------+----------------------------------------------------+
+
+The ``[nodeset]`` section defines NodeSet defaults.
+
++--------------------+----------------------------------------------------+
+| Key                | Value                                              |
++====================+====================================================+
+| fold_axis          | Axis or axes along which nD node sets are folded   |
+|                    | for display; empty by default, meaning that        |
+|                    | folding is computed on all axes (see               |
+|                    | :ref:`defaults-config-slurm`).                     |
++--------------------+----------------------------------------------------+
 
 Use case: rsh
 ^^^^^^^^^^^^^^

--- a/doc/sphinx/guide/nodesets.rst
+++ b/doc/sphinx/guide/nodesets.rst
@@ -120,6 +120,13 @@ And also for multidimensional node sets::
     >>> print nodeset[::2]
     clu[1-2]-[1-10]-ib0
 
+Conversely, to find the zero-based position of a node in the set, use the
+:meth:`.NodeSet.index()` method (the inverse of ``__getitem__``), for
+example::
+
+    >>> print NodeSet("node[10-49]").index("node20")
+    10
+
 .. _class-NodeSet-split:
 
 To split a NodeSet object into *n* subsets, use the :meth:`.NodeSet.split()`
@@ -196,7 +203,7 @@ Node groups are prefixed with **@** character. Please see
 rules.
 
 Please also have a look at :ref:`Node groups configuration <groups-config>` to
-learn how to configure external node group bingings (sources). Once setup
+learn how to configure external node group bindings (sources). Once setup
 (please use the :ref:`nodeset-tool` command to check your configuration), the
 NodeSet parsing engine automatically resolves node groups. For example::
 

--- a/doc/sphinx/guide/rangesets.rst
+++ b/doc/sphinx/guide/rangesets.rst
@@ -39,6 +39,13 @@ To iterate over the set's indexes as integers, you may use the new method
 :meth:`.RangeSet.intiter()`, which is the equivalent of iterating over the
 :class:`.RangeSet` object before v1.9.
 
+Since v1.10, the :meth:`.RangeSet.index()` method returns the zero-based
+position of an element, the reverse of :meth:`.RangeSet.__getitem__()`
+(zero-padding is significant when the element is given as a string)::
+
+    >>> RangeSet("10-49").index("20")
+    10
+
 .. _class-RangeSetND:
 
 RangeSetND class

--- a/doc/sphinx/tools/clubak.rst
+++ b/doc/sphinx/tools/clubak.rst
@@ -55,6 +55,14 @@ node groups in results, use ``-r, --regroup``::
 Likewise, the ``--axis`` option folds the displayed node set along selected
 *nD* axis only, as described in :ref:`clush-axis`.
 
+By default, *clubak* interprets each key (the field before the separator on
+input lines) as a node set. Use ``--interpret-keys=never`` to keep keys as
+plain strings instead, for example to gather lines by arbitrary, non-node
+keys, or ``--interpret-keys=always`` to require that every key is a valid node
+set. In ``auto`` mode (the default), *clubak* interprets keys as node sets,
+but silently switches to treating all keys as plain strings if any key
+cannot be parsed.
+
 Like *clush*, *clubak* uses the :mod:`ClusterShell.MsgTree` module of the ClusterShell
 library.
 
@@ -90,7 +98,7 @@ For example::
        bis_second_func()
 
 
-.. [#] *padb*, a parallel application debugger (http://padb.pittman.org.uk/)
+.. [#] *padb*, a parallel application debugger
 
 .. _ticket #166: https://github.com/clustershell/clustershell/issues/166
 .. _ticket: https://github.com/clustershell/clustershell/issues/new

--- a/doc/sphinx/tools/cluset.rst
+++ b/doc/sphinx/tools/cluset.rst
@@ -151,7 +151,7 @@ still recognize options as specified below.
 |                    | <groups-config>` for default *group source*         |
 |                    | configuration).                                     |
 +--------------------+-----------------------------------------------------+
-| ``--groupsources`` | List all configured *group sources*, one per line,  |
+| ``--list-sources`` | List all configured *group sources*, one per line,  |
 |                    | as configured in *groups.conf* (see                 |
 |                    | :ref:`groups configuration <groups-config>`).       |
 |                    | The default *group source* is appended with         |
@@ -159,6 +159,7 @@ still recognize options as specified below.
 |                    | option is specified. This command is mainly here to |
 |                    | avoid reading any configuration files, or to check  |
 |                    | if all work fine when configuring *group sources*.  |
+|                    | Also available as ``--groupsources``.               |
 +--------------------+-----------------------------------------------------+
 
 .. _cluset-commands-formatting:
@@ -702,9 +703,10 @@ Listing group sources
 
 As already mentioned, the following *cluset* command is available to list
 configured group sources and also display the default group source (unless
-``-q`` is provided)::
+``-q`` is provided). The ``--list-sources`` and ``--groupsources`` options
+are equivalent::
 
-    $ cluset --groupsources
+    $ cluset --list-sources
     local (default)
     genders
     slurm

--- a/doc/sphinx/tools/clush.rst
+++ b/doc/sphinx/tools/clush.rst
@@ -393,6 +393,10 @@ even if all nodes have successfully run the command. When you hit CTRL-C with
     2.6.18-164.11.1.el5
     Keyboard interrupt (node1 did not complete).
 
+.. note:: In standard (non-gathered) mode, *clush* prefixes each output line
+   with the name of the originating node; use the ``-N`` option to disable this
+   labeling.
+
 .. _clush-axis:
 
 Choosing fold axis (nD)

--- a/doc/sphinx/tools/nodeset.rst
+++ b/doc/sphinx/tools/nodeset.rst
@@ -150,7 +150,7 @@ still recognize options as specified below.
 |                    | <groups-config>` for default *group source*         |
 |                    | configuration).                                     |
 +--------------------+-----------------------------------------------------+
-| ``--groupsources`` | List all configured *group sources*, one per line,  |
+| ``--list-sources`` | List all configured *group sources*, one per line,  |
 |                    | as configured in *groups.conf* (see                 |
 |                    | :ref:`groups configuration <groups-config>`).       |
 |                    | The default *group source* is appended with         |
@@ -158,6 +158,7 @@ still recognize options as specified below.
 |                    | option is specified. This command is mainly here to |
 |                    | avoid reading any configuration files, or to check  |
 |                    | if all work fine when configuring *group sources*.  |
+|                    | Also available as ``--groupsources``.               |
 +--------------------+-----------------------------------------------------+
 
 .. _nodeset-commands-formatting:
@@ -701,9 +702,10 @@ Listing group sources
 
 As already mentioned, the following *nodeset* command is available to list
 configured group sources and also display the default group source (unless
-``-q`` is provided)::
+``-q`` is provided). The ``--list-sources`` and ``--groupsources`` options
+are equivalent::
 
-    $ nodeset --groupsources
+    $ nodeset --list-sources
     local (default)
     genders
     slurm

--- a/doc/txt/clubak.txt
+++ b/doc/txt/clubak.txt
@@ -44,8 +44,11 @@ OPTIONS
 --version      show ``clubak`` version number and exit
 -b, -c         gather nodes with same output (-c is provided for ``dshbak``\(1)
                compatibility)
+-B             same as -b; accepted for compatibility with ``clush``\(1), where -B also gathers standard error
+-v, --verbose  be verbose, print informative messages; also echo each input line to standard output prefixed by ``INPUT``
 -d, --debug    output more messages for debugging purpose
 -L             disable header block and order output by nodes
+-N             disable labeling of command line
 -r, --regroup  fold nodeset using node groups
 --axis=RANGESET
                for nD nodesets, fold the displayed nodeset (eg. in gathered output headers) along provided axis only. Axis are indexed from 1 to n and can be specified here either using the rangeset syntax, eg. '1', '1-2', '1,3', or by a single negative number meaning that the index is counted from the end. Because some nodesets may have several different dimensions, axis indices are silently truncated to fall in the allowed range. This is the per-invocation equivalent of the ``fold_axis`` library default.
@@ -59,6 +62,8 @@ OPTIONS
                node / line content separator string (default: `:`)
 -F, --fast     faster but memory hungry mode (preload all messages per node)
 -T, --tree     message tree trace mode; switch to enable ``ClusterShell.MsgTree`` trace mode, all keys/nodes being kept for each message element of the tree, thus allowing special output gathering
+--interpret-keys=INTERPRET_KEYS
+               whether to interpret keys (the field before the separator on each input line) as node sets. *INTERPRET_KEYS* is ``never``, ``always`` or ``auto`` (the default). With ``never``, each key is kept as a plain string; with ``always``, every key must be a valid node set; with ``auto``, keys are interpreted as node sets, but if any key cannot be parsed, ``clubak`` silently switches to treating all keys as plain strings.
 --color=WHENCOLOR   ``clush`` can use NO_COLOR, CLICOLOR and CLICOLOR_FORCE environment variables. ``--color`` command line option always takes precedence over environment variables. NO_COLOR takes precedence over CLICOLOR_FORCE which takes precedence over CLICOLOR. ``--color`` tells whether to use ANSI colors to surround node or nodeset prefix/header with escape sequences to display them in color on the terminal. *WHENCOLOR* is ``never``, ``always`` or ``auto`` (which use color if standard output refers to a terminal). Color is set to [34m (blue foreground text) and cannot be modified.
 --diff         show diff between gathered outputs
 

--- a/doc/txt/cluset.txt
+++ b/doc/txt/cluset.txt
@@ -51,7 +51,8 @@ OPTIONS
     -L, --list-all      list node groups from all group sources (``-LL`` shows nodes and ``-LLL`` adds node count). Like ``-l``, if any nodesets are specified as argument, this command will find node groups these nodes belongs to (individually).
     -r, --regroup       fold nodes using node groups (see -s *GROUPSOURCE*)
     --index=NODE        output the index of NODE in the nodeset (reverse of -I/--slice)
-    --groupsources      list all active group sources (see ``groups.conf``\(5))
+    --list-sources, --groupsources
+                        list all active group sources (see ``groups.conf``\(5))
 
   Operations:
     -x SUB_NODES, --exclude=SUB_NODES
@@ -153,7 +154,7 @@ Any wildcard mask found is matched against all nodes from the group source (see 
 ``*`` means match zero or more characters of any type; ``?`` means match exactly one character of any type.
 This can be especially useful for server farms, or when cluster node names differ.
 
-Say that your group configuration is set to return the following “all nodes”:
+Say that your group configuration is set to return the following "all nodes":
   :$ cluset -f -a:
   
   | bckserv[1-2],dbserv[1-4],wwwserv[1-9]

--- a/doc/txt/groups.conf.txt
+++ b/doc/txt/groups.conf.txt
@@ -66,6 +66,8 @@ confdir
   highest priority configuration directory found (where groups.conf resides).
   The default confdir value enables both system-wide and any installed user
   configuration (thanks to *$CFGDIR*). Duplicate directory paths are ignored.
+  ``groupsdir`` is accepted as an alias for ``confdir`` and takes precedence
+  when both are defined.
 
 autodir
   Optional list of directories where the ClusterShell library should look for
@@ -124,7 +126,8 @@ cache_time
 
 When the library executes a group source external shell command, the current
 working directory is previously set to the corresponding confdir. This
-allows the use of relative paths for third party files in the command.
+allows the use of relative paths for third party files in the command. The
+command's standard input is connected to */dev/null*.
 
 In addition to context-dependent $GROUP and $NODE variables described above, the
 two following variables are always available and also replaced before executing

--- a/doc/txt/nodeset.txt
+++ b/doc/txt/nodeset.txt
@@ -51,7 +51,8 @@ OPTIONS
     -L, --list-all      list node groups from all group sources (``-LL`` shows nodes and ``-LLL`` adds node count). Like ``-l``, if any nodesets are specified as argument, this command will find node groups these nodes belongs to (individually).
     -r, --regroup       fold nodes using node groups (see -s *GROUPSOURCE*)
     --index=NODE        output the index of NODE in the nodeset (reverse of -I/--slice)
-    --groupsources      list all active group sources (see ``groups.conf``\(5))
+    --list-sources, --groupsources
+                        list all active group sources (see ``groups.conf``\(5))
 
   Operations:
     -x SUB_NODES, --exclude=SUB_NODES
@@ -153,7 +154,7 @@ Any wildcard mask found is matched against all nodes from the group source (see 
 ``*`` means match zero or more characters of any type; ``?`` means match exactly one character of any type.
 This can be especially useful for server farms, or when cluster node names differ.
 
-Say that your group configuration is set to return the following “all nodes”:
+Say that your group configuration is set to return the following "all nodes":
   :$ nodeset -f -a:
   
   | bckserv[1-2],dbserv[1-4],wwwserv[1-9]

--- a/lib/ClusterShell/Defaults.py
+++ b/lib/ClusterShell/Defaults.py
@@ -146,6 +146,7 @@ class Defaults(object):
     * engine (string; default is ``'auto'``)
     * local_workername (string; default is ``'exec'``)
     * distant_workername (string; default is ``'ssh'``)
+    * auto_tree (boolean; default is ``True``)
     * debug (boolean; default is ``False``)
     * print_debug (function; default is internal)
     * fanout (integer; default is ``64``)

--- a/lib/ClusterShell/Event.py
+++ b/lib/ClusterShell/Event.py
@@ -61,6 +61,10 @@ class EventHandler(object):
 
         *New in version 1.7.*
 
+        *Changed in version 1.10:* in tree mode, ``ev_pickup`` now fires
+        only once a command can no longer be rerouted, so it fires at
+        most once per node.
+
         :param worker: :class:`.Worker` derived object
         :param node: node (or key)
         """


### PR DESCRIPTION
Follow-up doc fixes from the post-1.10 coverage audit. No behavior changes (lib edits are docstring-only).

- clubak: document `--interpret-keys`, `-v/--verbose`, `-N`, `-B`
- config.rst: enumerate the defaults.conf keys by section; document the `groupsdir` alias and that upcalls get no stdin; add a topology.conf section
- nodeset/cluset: document the `--list-sources` primary alias; fix curly quotes in the NODE WILDCARDS example
- clush.rst: mention `-N`
- API autodoc: add `UpcallGroupSource`, `MsgTreeElem`, `set_std_group_resolver_config`, `EnginePort` (fixes unresolved xrefs)
- docstrings: `auto_tree` (Defaults), `ev_pickup` tree-mode note (Event)
- guide: cross-reference `NodeSet.index()` / `RangeSet.index()`; fix a typo; drop a dead link

Man pages regenerated with docutils 0.20.1.