### PR TITLE
CI: add docs build workflow (sphinx -W)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,21 @@
+name: docs
+
+on: [push, pull_request, merge_group]
+
+permissions:
+  contents: read
+
+jobs:
+  sphinx:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5.2.0
+      with:
+        python-version: '3.12'  # same as .readthedocs.yaml
+    - name: Install docs requirements (same pins as ReadTheDocs)
+      run: pip install -r doc/sphinx/requirements.txt
+    - name: Build docs with warnings as errors
+      run: sphinx-build -W --keep-going -b html doc/sphinx /tmp/html


### PR DESCRIPTION
Add a GitHub Actions workflow that builds the Sphinx docs with warnings as errors, so doc breakage fails PRs early instead of post-merge on ReadTheDocs.

- Mirrors RTD: same pins (`doc/sphinx/requirements.txt`) and same Python (3.12) as `.readthedocs.yaml`; RTD already enforces `fail_on_warning: true`.
- Runs on all PRs (no paths filter): autodoc imports the library, so broken docstring markup in `lib/` fails the build too.
- Includes the `merge_group` trigger like tests.yml so the check reports in the merge queue.

After merge, the `sphinx` check (shown as "docs / sphinx" on PRs) can be added to the required status checks to make it blocking.