### PR TITLE
tests: use printf instead of echo -n for portability

### DIFF
--- a/tests/TaskDistantMixin.py
+++ b/tests/TaskDistantMixin.py
@@ -307,7 +307,7 @@ class TaskDistantMixin(object):
     def testShellEventsReadNoEOL(self):
         # init worker
         test_eh = self.__class__.TEventHandlerChecker(self)
-        worker = self._task.shell("/bin/echo -n okay", nodes=HOSTNAME, handler=test_eh)
+        worker = self._task.shell("printf okay", nodes=HOSTNAME, handler=test_eh)
         # run task
         self._task.resume()
         # test events received: start, close

--- a/tests/TaskLocalMixin.py
+++ b/tests/TaskLocalMixin.py
@@ -84,7 +84,7 @@ class TaskLocalMixin(object):
         task = task_self()
 
         # init worker
-        worker = task.shell("for i in $(seq 1 100000); do echo -n ' huge! '; done")
+        worker = task.shell("for i in $(seq 1 100000); do printf ' huge! '; done")
 
         # run task
         task.resume()
@@ -695,7 +695,7 @@ class TaskLocalMixin(object):
     def testSimpleCommandReadNoEOL(self):
         task = task_self()
         # init worker
-        worker = task.shell("echo -n okay")
+        worker = task.shell("printf okay")
         # run task
         task.resume()
         self.assertEqual(worker.read(), b"okay")

--- a/tests/WorkerExecTest.py
+++ b/tests/WorkerExecTest.py
@@ -28,7 +28,7 @@ class ExecTest(unittest.TestCase):
 
     def test_shell_syntax(self):
         """test ExecWorker with a command using shell syntax"""
-        cmd = "echo -n 1; echo -n 2"
+        cmd = "printf 1; printf 2"
         self.execw(nodes='localhost', handler=None, command=cmd)
         self.assertEqual(task_self().max_retcode(), 0)
         self.assertEqual(task_self().node_buffer('localhost'), b'12')


### PR DESCRIPTION
`echo -n` is implementation-defined in POSIX; macOS `/bin/sh` prints the
`-n` literally, which fails `testSimpleCommandReadNoEOL`,
`testHugeOutputCommand` (both engines) and `ExecTest::test_shell_syntax`
on macOS. Use `printf`, which behaves identically everywhere. Also
switched `/bin/echo -n` in `TaskDistantMixin.py` for consistency.

Test-only change; no library code affected. Verified on macOS 26.3.1:
the non-SSH test subset now fully passes.