### PR TITLE
Documentation: refresh installation guide

### DIFF
--- a/doc/sphinx/install.rst
+++ b/doc/sphinx/install.rst
@@ -17,7 +17,8 @@ Requirements
 ------------
 
 ClusterShell should work with any Unix [#]_ operating systems which provides
-Python 2.7 or 3.x and OpenSSH or any compatible Secure Shell clients.
+Python 2.7 or 3.x and OpenSSH or any compatible Secure Shell clients. It is
+regularly tested with Python 3.7 up to Python 3.14.
 
 .. warning:: While we are making our best effort to maintain Python 2
    compatibility in the ClusterShell 1.10 series, we no longer run tests for
@@ -26,29 +27,27 @@ Python 2.7 or 3.x and OpenSSH or any compatible Secure Shell clients.
    Python 2; ClusterShell 1.11 will require Python 3. For the best experience
    and continued support, it is strongly recommended to use Python 3.
 
-Furthermore, ClusterShell's engine has been optimized when the ``poll()``
-syscall is available or even better, when the ``epoll_wait()`` syscall is
-available (Linux only).
-
 For instance, ClusterShell is known to work on the following operating systems:
 
 * GNU/Linux
-
-  * Red Hat Enterprise Linux 7 (Python 2.7)
 
   * Red Hat Enterprise Linux 8 (Python 3.6)
 
   * Red Hat Enterprise Linux 9 (Python 3.9)
 
-  * Fedora 30 and above (Python 2.7 to 3.10+)
+  * Red Hat Enterprise Linux 10 (Python 3.12)
 
-  * Debian 10 "buster" (Python 3.7)
+  * Fedora 42 and above (Python 3.13+)
 
-  * Debian 11 "bullseye" (Python 3.9)
+  * Debian 12 "bookworm" (Python 3.11)
 
-  * Ubuntu 20.04 (Python 3.8)
+  * Debian 13 "trixie" (Python 3.13)
 
-* Mac OS X 12+ (Python 2.7 and 3.8)
+  * Ubuntu 22.04 LTS (Python 3.10)
+
+  * Ubuntu 24.04 LTS (Python 3.12)
+
+* macOS (Python 3)
 
 Distribution
 ------------
@@ -60,79 +59,40 @@ ClusterShell should remain easily available to everyone. Hopefully, packages are
 currently available for Fedora Linux, RHEL (through EPEL repositories), Debian,
 Arch Linux and more.
 
-.. _install-python-support-overview:
-
-Python support overview
-^^^^^^^^^^^^^^^^^^^^^^^
-
-As seen in :ref:`install-requirements`, ClusterShell supports Python 2.7 and
-onwards, and is regularly tested with Python 3.7 up to Python 3.14 at the time
-of writing.
-
-The table below provides a few examples of versions of Python supported by
-ClusterShell packages as found in some common Linux distributions:
-
-+------------------+----------------------------+-----------------------------------+
-| Operating        | System Python version used | Alternate Python support          |
-| System           | by the clustershell tools  | packaged (version-suffixed tools) |
-+==================+============================+===================================+
-| RHEL 7           | Python 2.7                 | Python 3.6                        |
-+------------------+----------------------------+-----------------------------------+
-| RHEL 8           | **Python 3.6**             |                                   |
-+------------------+----------------------------+-----------------------------------+
-| RHEL 9           | **Python 3.9**             |                                   |
-+------------------+----------------------------+-----------------------------------+
-| Fedora 36        | **Python 3.10**            |                                   |
-+------------------+----------------------------+-----------------------------------+
-| openSUSE Leap 15 | Python 2.7                 | Python 3.6                        |
-+------------------+----------------------------+-----------------------------------+
-| SUSE SLES 12     | Python 2.7                 | Python 3.4                        |
-+------------------+----------------------------+-----------------------------------+
-| SUSE SLES 15     | Python 2.7                 | Python 3.6                        |
-+------------------+----------------------------+-----------------------------------+
-| Ubuntu 18.04 LTS | **Python 3.6**             |                                   |
-+------------------+----------------------------+-----------------------------------+
-| Ubuntu 20.04 LTS | **Python 3.8**             |                                   |
-+------------------+----------------------------+-----------------------------------+
-
 Red Hat Enterprise Linux
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 ClusterShell packages are maintained on Extra Packages for Enterprise Linux
 `EPEL`_ for Red Hat Enterprise Linux (RHEL) and its compatible spinoffs such
-as `Alma Linux`_ and `Rocky Linux`_. At the time of writing, ClusterShell |version|
-is available on EPEL 8 and 9.
+as `Alma Linux`_ and `Rocky Linux`_. ClusterShell is currently available on
+EPEL 8, 9 and 10.
 
 
 Install ClusterShell from EPEL
 """"""""""""""""""""""""""""""
 
-First you have to enable the ``yum`` EPEL repository. We recommend to download
-and install the `EPEL`_ repository RPM package. On CentOS, this can be easily
-done using the following command::
+First you have to enable the EPEL repository. We recommend to download and
+install the `EPEL`_ repository RPM package. On Alma Linux and Rocky Linux,
+this can be easily done using the following command::
 
-    $ dnf --enablerepo=extras install epel-release
+    $ dnf install epel-release
 
-Then, the ClusterShell installation procedure is quite the same as for
-*Fedora Updates*, for instance::
+Then, install ClusterShell's library module and tools using the following
+command::
 
     $ dnf install clustershell
 
-The Python 3 modules and tools are installed by default with ``clustershell``.
-If interested in the Python 3 library only, you can install ClusterShell's
-Python 3 subpackage using the following command::
+The tools and the Python 3 library module are installed by default with
+``clustershell``. If interested in the Python 3 library only, you can install
+ClusterShell's Python 3 subpackage using the following command::
 
     $ dnf install python3-clustershell
-
-With EPEL 8 and 9, however, Python 3 is the system default, and Python 2 has
-been deprecated. Thus only Python 3 is supported by the EPEL clustershell
-packages, the tools are using Python 3 by default and are not suffixed anymore.
 
 Fedora
 ^^^^^^
 
-At the time of writing, ClusterShell |version| is available on Fedora 41
-(releases being maintained by the Fedora Project).
+ClusterShell is available in all Fedora releases currently maintained by the
+Fedora Project.
 
 Install ClusterShell from *Fedora Updates*
 """"""""""""""""""""""""""""""""""""""""""
@@ -144,25 +104,18 @@ system::
 
     $ dnf list \*clustershell
     Available Packages
-    clustershell.noarch                     1.8-1.fc26                fedora
-    python2-clustershell.noarch             1.8-1.fc26                fedora
-    python3-clustershell.noarch             1.8-1.fc26                fedora
+    clustershell.noarch                     1.9.3-6.fc43              updates
+    python3-clustershell.noarch             1.9.3-6.fc43              updates
 
 Then, install ClusterShell's library module and tools using the following
 command::
 
     $ dnf install clustershell
 
-Prior to Fedora 31, Python 2 modules and tools were installed by default. If
-interested in Python 3 support, simply install the additional ClusterShell's
+If interested in the Python 3 library only, you can install ClusterShell's
 Python 3 subpackage using the following command::
 
     $ dnf install python3-clustershell
-
-Prior to Fedora 31, Python 3 versions of the tools are installed as
-*tool-pythonversion*, like ``clush-3.6``, ``cluset-3.6`` or ``nodeset-3.6``.
-
-On Fedora 31 and onwards, only Python 3 is supported.
 
 Install ClusterShell from Fedora Updates Testing
 """"""""""""""""""""""""""""""""""""""""""""""""
@@ -182,31 +135,16 @@ instance::
 openSUSE
 ^^^^^^^^
 
-ClusterShell is available in openSUSE Tumbleweed (Factory) and Leap since 2017::
-
-    $ zypper search clustershell
-    Loading repository data...
-    Reading installed packages...
-
-    S | Name                 | Summary                                               | Type
-    --+----------------------+-------------------------------------------------------+--------
-      | clustershell         | Python framework for efficient cluster administration | package
-      | python2-clustershell | ClusterShell module for Python 2                      | package
-      | python3-clustershell | ClusterShell module for Python 3                      | package
-
+ClusterShell is available in openSUSE Tumbleweed (Factory) and Leap since 2017.
 
 To install ClusterShell on openSUSE, use::
 
     $ zypper install clustershell
 
-Python 2 module and tools are installed by default. If interested in Python 3 support,
-simply install the additional ClusterShell's Python 3 subpackage
-using the following command::
+If interested in the Python 3 library only, you can install ClusterShell's
+Python 3 subpackage using the following command::
 
     $ zypper install python3-clustershell
-
-Python 3 versions of the tools are installed as *tool-pythonversion*, like
-``clush-3.6``, ``cluset-3.6`` or ``nodeset-3.6``.
 
 Debian
 ^^^^^^
@@ -219,17 +157,16 @@ To install it on Debian, simply use::
 
 You can get the latest version on::
 
-* http://packages.debian.org/sid/clustershell
+* https://packages.debian.org/sid/clustershell
 
 
 Ubuntu
 ^^^^^^
 
 Like Debian, it is easy to get and install ClusterShell on Ubuntu (also with
-``apt-get``). To do so, please first enable the **universe** repository.
-ClusterShell is available since "Natty" release (11.04):
+``apt-get``). To do so, please first enable the **universe** repository:
 
-* http://packages.ubuntu.com/clustershell
+* https://packages.ubuntu.com/clustershell
 
 .. _install-python:
 
@@ -263,6 +200,10 @@ the library, and finally ``MANPATH`` for the man pages::
     $ export PYTHONPATH=$PYTHONPATH:~/.local/lib
     $ export MANPATH=$MANPATH:$HOME/.local/share/man
 
+.. note:: On macOS, ``pip install --user`` places the tools in
+   ``~/Library/Python/3.x/bin`` instead of ``~/.local/bin``; adjust ``PATH``
+   accordingly.
+
 Configuration files are installed in ``~/.local/etc/clustershell`` and are
 automatically loaded before system-wide ones (for more info about supported
 user config files, please see the :ref:`clush-config` or :ref:`groups-config`
@@ -279,6 +220,12 @@ in an isolated environment::
     $ python3 -m venv venv
     $ source venv/bin/activate
     $ pip install ClusterShell
+
+.. note:: Scripts that import the ClusterShell library must run with the
+   Python interpreter where ClusterShell is installed: use
+   ``#!/usr/bin/python3`` with distribution packages or
+   ``pip install --user``, or your virtual environment's interpreter
+   (eg. ``#!/usr/bin/env python3`` with the environment activated).
 
 .. _install-source:
 
@@ -297,8 +244,8 @@ the latest development version from the repository::
    those found in the Python Package Index
 
 .. _LGPL v2.1+: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-.. _Test Updates: http://fedoraproject.org/wiki/QA/Updates_Testing
-.. _EPEL: http://fedoraproject.org/wiki/EPEL
+.. _Test Updates: https://fedoraproject.org/wiki/QA/Updates_Testing
+.. _EPEL: https://fedoraproject.org/wiki/EPEL
 .. _Alma Linux: https://almalinux.org/
 .. _Rocky Linux: https://rockylinux.org/
 .. _venv: https://docs.python.org/3/tutorial/venv.html

--- a/doc/sphinx/release.rst
+++ b/doc/sphinx/release.rst
@@ -371,8 +371,7 @@ This version contains a few bug fixes and improvements, mostly affecting the
 
 For more details, please have a look at `GitHub Issues for 1.8.3 milestone`_.
 
-We also added a :ref:`Python support matrix <install-python-support-overview>`
-for the main Linux distributions.
+We also added a Python support matrix for the main Linux distributions.
 
 
 Version 1.8.2


### PR DESCRIPTION
Refresh stale content in the installation guide:

- drop the poll/epoll paragraph (engine selection is automatic and documented with the library defaults) and the outdated Python support matrix
- refresh the known-to-work OS list: RHEL 8/9/10, Fedora 42+, Debian 12/13, Ubuntu 22.04/24.04 LTS, macOS
- EPEL: ClusterShell is available on EPEL 8, 9 and 10
- remove Python 2-era install instructions (EPEL, Fedora, openSUSE)
- add a macOS note for pip --user installs
- update example outputs and links