### PR TITLE
Documentation: accuracy fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ of the library features.
 Requirements
 ------------
 
- * GNU/Linux, BSD, Mac OS X
+ * GNU/Linux, BSD, macOS
  * OpenSSH (ssh/scp) or rsh
  * Python 2.x (x >= 7) or Python 3.x (x >= 6)
  * PyYAML
@@ -43,9 +43,9 @@ Online documentation is available here:
     https://clustershell.readthedocs.io/
 
 The Sphinx documentation source is available under the doc/sphinx directory.
-Type 'make' to see all available formats (you need Sphinx installed and
-sphinx_rtd_theme to build the documentation). For example, to generate html
-docs, just type:
+Type 'make' to see all available formats (you need the packages listed in
+doc/sphinx/requirements.txt to build the documentation). For example, to
+generate html docs, just type:
 
     make html BUILDDIR=/dest/path
 
@@ -55,7 +55,7 @@ For local library API documentation, just type:
 
 The following man pages are also provided:
 
-    clush(1), clubak(1), nodeset(1), clush.conf(5), groups.conf(5)
+    clush(1), clubak(1), cluset(1), nodeset(1), clush.conf(5), groups.conf(5)
 
 Building
 --------

--- a/doc/man/man1/clubak.1
+++ b/doc/man/man1/clubak.1
@@ -55,12 +55,15 @@ ClusterShell library (see \fBpydoc ClusterShell.MsgTree\fP).
 .B  \-\-version
 show \fBclubak\fP version number and exit
 .TP
-.B  \-b\fP,\fB  \-c
-gather nodes with same output (\-c is provided for \fBdshbak\fP(1)
-compatibility)
+.B  \-b\fP,\fB  \-c\fP,\fB  \-\-dshbak
+gather nodes with same output (\-c and \-\-dshbak are provided
+for \fBdshbak\fP(1) compatibility)
 .TP
 .B  \-B
 same as \-b; accepted for compatibility with \fBclush\fP(1), where \-B also gathers standard error
+.TP
+.B  \-q\fP,\fB  \-\-quiet
+be quiet, print essential output only (eg. suppress the node count displayed next to gathered nodeset headers)
 .TP
 .B  \-v\fP,\fB  \-\-verbose
 be verbose, print informative messages; also echo each input line to standard output prefixed by \fBINPUT\fP

--- a/doc/sphinx/guide/taskmgnt.rst
+++ b/doc/sphinx/guide/taskmgnt.rst
@@ -43,11 +43,11 @@ Example of getting the current task object::
 So for a single-threaded application, a Task is a simple singleton (which
 instance is also available through :func:`.Task.task_self()`).
 
-To get the *Task* object associated to a specific thread identified by the
-identifier *tid*, you use the following::
+To get the *Task* object associated to a specific thread *thr* (a
+``threading.Thread`` object), you use the following::
 
     >>> from ClusterShell.Task import Task
-    >>> task = Task(thread_id=tid)
+    >>> task = Task(thread=thr)
 
 
 .. _class-Task-configure:
@@ -258,13 +258,13 @@ Changing default worker
 
 When calling :meth:`.Task.shell` or :meth:`.Task.copy` the Task object creates
 a worker instance for each call. When the *nodes* argument is defined, the
-worker class used for these calls is based on Task default *distant_worker*.
-Change this value to use another worker class, by example **Rsh**::
+worker used for these calls is based on Task default *distant_workername*
+(default: ``ssh``). Change this value to use another worker, by example
+**rsh**::
 
     from ClusterShell.Task import task_self
-    from ClusterShell.Worker.Rsh import WorkerRsh
 
-    task_self().set_default('distant_worker', WorkerRsh)
+    task_self().set_default('distant_workername', 'rsh')
 
 
 Thread safety and Task objects

--- a/doc/sphinx/tools/nodeset.rst
+++ b/doc/sphinx/tools/nodeset.rst
@@ -1130,7 +1130,7 @@ example (Bourne shell), making it sort of a super `seq(1)`_ command::
     0 2 4 6 8
 
 
-.. [#] SLURM is an open-source resource manager (https://computing.llnl.gov/linux/slurm/)
+.. [#] Slurm is an open-source resource manager (https://slurm.schedmd.com/overview.html)
 
 .. _seq(1): http://linux.die.net/man/1/seq
 

--- a/doc/txt/README
+++ b/doc/txt/README
@@ -1,4 +1,4 @@
 Files found in this directory are text files in reStructuredText format (Markup Syntax of Docutils).
-We use rst1man.py to convert them to roff man pages.
+We use rst2man (docutils) to convert them to roff man pages.
 
-See: http://docutils.sourceforge.net/rst.html
+See: https://docutils.sourceforge.io/rst.html

--- a/doc/txt/clubak.txt
+++ b/doc/txt/clubak.txt
@@ -42,9 +42,11 @@ OPTIONS
 =======
 
 --version      show ``clubak`` version number and exit
--b, -c         gather nodes with same output (-c is provided for ``dshbak``\(1)
-               compatibility)
+-b, -c, --dshbak
+               gather nodes with same output (-c and --dshbak are provided
+               for ``dshbak``\(1) compatibility)
 -B             same as -b; accepted for compatibility with ``clush``\(1), where -B also gathers standard error
+-q, --quiet    be quiet, print essential output only (eg. suppress the node count displayed next to gathered nodeset headers)
 -v, --verbose  be verbose, print informative messages; also echo each input line to standard output prefixed by ``INPUT``
 -d, --debug    output more messages for debugging purpose
 -L             disable header block and order output by nodes

--- a/lib/ClusterShell/Task.py
+++ b/lib/ClusterShell/Task.py
@@ -476,9 +476,11 @@ class Task(object):
           - "stderr_msgtree": Same for stderr (default: True).
           - "engine": Used to specify an underlying Engine explicitly
             (default: "auto").
-          - "port_qlimit": Size of port messages queue (default: 32).
-          - "worker": Worker-based class used when spawning workers through
-            shell()/run().
+          - "port_qlimit": Size of port messages queue (default: 100).
+          - "local_workername": Worker name used when spawning workers
+            for local commands (default: "exec").
+          - "distant_workername": Worker name used when spawning workers
+            for distant commands (default: "ssh").
 
         Threading considerations:
 
@@ -529,7 +531,7 @@ class Task(object):
           - "fanout": Max number of registered clients in Engine at a
             time (default: 64).
           - "grooming_delay": Message maximum end-to-end delay requirement
-            used for traffic grooming, in seconds as float (default: 0.5).
+            used for traffic grooming, in seconds as float (default: 0.25).
           - "connect_timeout": Time in seconds to wait for connecting to
             remote host before aborting (default: 10).
           - "command_timeout": Time in seconds to wait for a command to


### PR DESCRIPTION
Fix documentation inaccuracies found while preparing 1.10.1:

- Programming guide: `Task(thread_id=tid)` raises TypeError — the constructor takes a `threading.Thread` object (`Task(thread=thr)`). Also use the documented `distant_workername` string default instead of the internal `distant_worker` class key.
- `Task.set_default()`/`set_info()` docstrings (rendered in the API docs): fix `port_qlimit` (100) and `grooming_delay` (0.25) defaults, and replace the unused `worker` key with `local_workername`/`distant_workername`.
- clubak: document working options `-q, --quiet` and `--dshbak`; man page regenerated.
- nodeset docs: replace the dead computing.llnl.gov Slurm link (404) with the schedmd.com link already used in the cluset docs.
- README: add cluset(1) to the man page list, macOS naming, and point doc builds at doc/sphinx/requirements.txt (sphinxcontrib-asciinema is also required).
- doc/txt/README: the tool is rst2man, not "rst1man.py".