### PR TITLE
RangeSet: cache sorted elements between mutations

### DIFF
--- a/lib/ClusterShell/RangeSet.py
+++ b/lib/ClusterShell/RangeSet.py
@@ -121,12 +121,15 @@ class RangeSet(set):
     """
     _VERSION = 4    # serial version number
 
+    _sorted_cache = None    # built by _sorted(), reset by every mutator
+
     def __init__(self, pattern=None, autostep=None):
         """Initialize RangeSet object.
 
         :param pattern: optional string pattern
         :param autostep: optional autostep threshold
         """
+        self._sorted_cache = None
         set.__init__(self)
 
         if pattern is not None and not isinstance(pattern, basestring):
@@ -308,9 +311,11 @@ class RangeSet(set):
         return (len(elem), elem)
 
     def _sorted(self):
-        """Get sorted list from inner set."""
-        # For mixed padding support, sort by both string length and index
-        return sorted(set.__iter__(self), key=self._sortkey)
+        """Get sorted list from inner set (cached; callers must not mutate)."""
+        if self._sorted_cache is None:
+            # For mixed padding support, sort by both string length and index
+            self._sorted_cache = sorted(set.__iter__(self), key=self._sortkey)
+        return self._sorted_cache
 
     def __iter__(self):
         """Iterate over each element in RangeSet, currently as integers, with
@@ -595,6 +600,7 @@ class RangeSet(set):
         Like the Python built-in function *range()*, the last element
         is the largest start + i * step less than stop.
         """
+        self._sorted_cache = None
         assert start < stop, "please provide ordered node index ranges"
         assert step > 0
         assert pad >= 0
@@ -761,6 +767,7 @@ class RangeSet(set):
 
     def __ior__(self, other):
         """Update a RangeSet with the union of itself and another."""
+        self._sorted_cache = None
         self._binary_sanity_check(other)
         set.__ior__(self, other)
         return self
@@ -771,17 +778,20 @@ class RangeSet(set):
 
     def __iand__(self, other):
         """Update a RangeSet with the intersection of itself and another."""
+        self._sorted_cache = None
         self._binary_sanity_check(other)
         set.__iand__(self, other)
         return self
 
     def intersection_update(self, other):
         """Update a RangeSet with the intersection of itself and another."""
+        self._sorted_cache = None
         set.intersection_update(self, other)
 
     def __ixor__(self, other):
         """Update a RangeSet with the symmetric difference of itself and
         another."""
+        self._sorted_cache = None
         self._binary_sanity_check(other)
         set.symmetric_difference_update(self, other)
         return self
@@ -789,10 +799,12 @@ class RangeSet(set):
     def symmetric_difference_update(self, other):
         """Update a RangeSet with the symmetric difference of itself and
         another."""
+        self._sorted_cache = None
         set.symmetric_difference_update(self, other)
 
     def __isub__(self, other):
         """Remove all elements of another set from this RangeSet."""
+        self._sorted_cache = None
         self._binary_sanity_check(other)
         set.difference_update(self, other)
         return self
@@ -802,6 +814,7 @@ class RangeSet(set):
 
         If strict is True, raise KeyError if an element cannot be removed.
         (strict is a RangeSet addition)"""
+        self._sorted_cache = None
         if strict and other not in self:
             raise KeyError(set.difference(other, self).pop())
         set.difference_update(self, other)
@@ -810,6 +823,7 @@ class RangeSet(set):
 
     def update(self, iterable):
         """Add all indexes (as strings) from an iterable (such as a list)."""
+        self._sorted_cache = None
         assert not isinstance(iterable, basestring)
         set.update(self, iterable)
 
@@ -825,9 +839,10 @@ class RangeSet(set):
 
     def clear(self):
         """Remove all elements from this RangeSet."""
+        self._sorted_cache = None
         set.clear(self)
 
-    # Single-element mutations: add, remove, discard
+    # Single-element mutations: add, remove, discard, pop
 
     def add(self, element, pad=0):
         """Add an element to a RangeSet.
@@ -840,6 +855,7 @@ class RangeSet(set):
         :param element: the element to add (integer or string)
         :param pad: zero padding length (integer); ignored if element is string
         """
+        self._sorted_cache = None
         if isinstance(element, basestring):
             set.add(self, element)
         else:
@@ -857,6 +873,7 @@ class RangeSet(set):
         :raises KeyError: element is not contained in RangeSet
         :raises ValueError: element is not castable to integer
         """
+        self._sorted_cache = None
         if isinstance(element, basestring):
             set.remove(self, element)
         else:
@@ -874,6 +891,7 @@ class RangeSet(set):
         :param element: the element to remove (integer or string)
         :param pad: zero padding length (integer); ignored if element is string
         """
+        self._sorted_cache = None
         try:
             if isinstance(element, basestring):
                 set.discard(self, element)
@@ -881,6 +899,14 @@ class RangeSet(set):
                 set.discard(self, "%0*d" % (pad, int(element)))
         except ValueError:
             pass # ignore other object types
+
+    def pop(self):
+        """Remove and return an arbitrary RangeSet element.
+
+        :raises KeyError: the RangeSet is empty
+        """
+        self._sorted_cache = None
+        return set.pop(self)
 
 
 class RangeSetND(object):

--- a/tests/RangeSetNDTest.py
+++ b/tests/RangeSetNDTest.py
@@ -557,3 +557,21 @@ class RangeSetNDTest(unittest.TestCase):
         rs3.add(4)
         self.assertEqual(str(rs3), "2-4")
         self.assertEqual(str(rn0), "2-5; 0-1\n6-7; 2-3\n")
+
+    def test_fold_update_fold(self):
+        """test folding interleaved with updates (sorted view cache)"""
+        def rebuilt(rgnd):
+            # re-parse the string representation into a new object
+            vecs = [line.split('; ') for line in str(rgnd).splitlines()]
+            return RangeSetND(vecs)
+
+        rn = RangeSetND([["0-10", "1-2"], ["5-15", "0-1"]])
+        self.assertEqual(len(rn), 38)
+        self.assertEqual(rn, rebuilt(rn))
+        rn.update(RangeSetND([["11-16", "1-2"]]))
+        self.assertEqual(len(rn), 45)
+        self.assertEqual(rn, rebuilt(rn))
+        self.assertTrue(RangeSetND([["16", "1"]]) in rn)
+        rn.update(RangeSetND([["0-4,16", "0"]]))
+        self.assertEqual(len(rn), 51)
+        self.assertEqual(str(rn), "0-16; 0-2\n")

--- a/tests/RangeSetTest.py
+++ b/tests/RangeSetTest.py
@@ -1412,3 +1412,81 @@ class RangeSetTest(unittest.TestCase):
         self.assertRaises(RangeSetParseError, RangeSet, "-009")
         self.assertRaises(RangeSetParseError, RangeSet, "-01-00")
         self.assertRaises(RangeSetParseError, RangeSet, "-003--001")
+
+    def test_sorted_view_after_mutation(self):
+        """test that each mutator refreshes the cached sorted view"""
+        # each read primes the sorted view cache, each mutation must drop it
+        rset = RangeSet("5-7")
+        self.assertEqual(str(rset), "5-7")
+        rset.add(9)
+        self.assertEqual(str(rset), "5-7,9")
+        rset.remove(9)
+        self.assertEqual(str(rset), "5-7")
+        rset.discard(7)
+        self.assertEqual(str(rset), "5-6")
+        rset.update(RangeSet("8-10"))
+        self.assertEqual(str(rset), "5-6,8-10")
+        rset.updaten([RangeSet("7"), RangeSet("11")])
+        self.assertEqual(str(rset), "5-11")
+        rset.add_range(20, 23)
+        self.assertEqual(str(rset), "5-11,20-22")
+        rset.difference_update(RangeSet("20-22"))
+        self.assertEqual(str(rset), "5-11")
+        rset.intersection_update(RangeSet("6-99"))
+        self.assertEqual(str(rset), "6-11")
+        rset.symmetric_difference_update(RangeSet("11-13"))
+        self.assertEqual(str(rset), "6-10,12-13")
+        rset |= RangeSet("14")
+        self.assertEqual(str(rset), "6-10,12-14")
+        rset -= RangeSet("14")
+        self.assertEqual(str(rset), "6-10,12-13")
+        rset &= RangeSet("6-12")
+        self.assertEqual(str(rset), "6-10,12")
+        rset ^= RangeSet("12-13")
+        self.assertEqual(str(rset), "6-10,13")
+        rset.clear()
+        self.assertEqual(str(rset), "")
+        rset = RangeSet("1-3")
+        self.assertEqual(str(rset), "1-3")
+        rset.padding = 3
+        self.assertEqual(str(rset), "001-003")
+        rset.__init__()
+        self.assertEqual(str(rset), "")
+
+    def test_sorted_view_after_mutation_indexing(self):
+        """test indexing and iteration after mutation"""
+        rset = RangeSet("1-3")
+        self.assertEqual(rset[0], "1")
+        rset.add(0)
+        self.assertEqual(rset[0], "0")
+        self.assertEqual(list(rset), ["0", "1", "2", "3"])
+        rset.discard(0)
+        self.assertEqual(list(rset), ["1", "2", "3"])
+        self.assertEqual(str(rset[0:2]), "1-2")
+
+    def test_set_mutators_are_overridden(self):
+        """test that RangeSet overrides all in-place set mutators"""
+        # the methods of set that frozenset does not have are the in-place
+        # mutators: each one must drop the cached sorted view, a behavior
+        # checked by test_sorted_view_after_mutation()
+        mutators = set(vars(set)) - set(vars(frozenset))
+        mutators.discard('__getattribute__')  # not a mutator
+        self.assertIn('add', mutators)  # sanity check of the above
+        missing = mutators - set(vars(RangeSet))
+        self.assertEqual(missing, set(),
+                         "set mutators not overridden: %s" % sorted(missing))
+
+    def test_pop(self):
+        """test RangeSet.pop()"""
+        rset = RangeSet("1-3")
+        self.assertEqual(str(rset), "1-3")
+        elem = rset.pop()
+        self.assertTrue(elem in ["1", "2", "3"])
+        self.assertEqual(len(rset), 2)
+        self.assertTrue(elem not in rset)
+        remaining = sorted({"1", "2", "3"} - {elem}, key=int)
+        self.assertEqual(list(rset), remaining)
+        rset = RangeSet("05")
+        self.assertEqual(rset.pop(), "05")
+        self.assertEqual(len(rset), 0)
+        self.assertRaises(KeyError, rset.pop)


### PR DESCRIPTION
Cache the result of `RangeSet._sorted()` and invalidate it on mutation, instead of re-sorting the inner set on every read. Caching only, no behavior change.

- All reads already funnel through `_sorted()`, so the cache lives in that one method.
- Every mutating method drops the cache with an inline `self._sorted_cache = None` as its first statement — before the mutation runs, so a failing mutator cannot leave a stale view. An earlier revision used a decorator; a Python frame per mutation cost ~200ns against ~25ns for the plain store, which is +65% on a `RangeSet.add()` loop.
- New `pop()` override: it was inherited from `set` and would have bypassed invalidation.
- New unit tests cover invalidation across every mutator, `pop()`, and folding interleaved with updates. A further test derives the mutator list as `set(vars(set)) - set(vars(frozenset))` — those are exactly the in-place mutators — and asserts `RangeSet` overrides each one, so a new `set` mutator in a future Python fails the test instead of silently bypassing the cache.
- No `RangeSetND` change needed here: nD folding only uses public `RangeSet` operations. #656 adds a raw `set.update(gvec[pos], rgvec[pos])` in `_fold_multivariate_merge`; whichever of the two lands second should route that through `update()` so the cache is dropped.

Read times (Python 3.13, 100k-element sets):

| operation | before | after |
|---|---|---|
| `str(rs)` | 139ms | 23ms cached, 133ms first call |
| `list(rs)` | 108ms | 0.8ms |
| `rs[50000]` | 109ms | 0.2us |
| `rs.split(32)` | 3.5s | 124ms first call, 4.2ms cached |
| `NodeSet("node[0-99999]").split(32)` | 3.6s | 7.2ms |
| `str()` of the same NodeSet | 140ms | 25ms |

Per-element mutation costs ~25ns more per call (+7% on a 50k `add()` loop with integers, +21% with strings, unchanged on `add_range()` and the set operators).

Extra memory: ~0.8MB per 100k elements while the cache is live.

Also tested on Python 2.7.5 (full RangeSet/NodeSet suite + randomized differential fuzzing).
