### PR TITLE
Fix gateway message pickle protocol and empty RangeSet pickle

### DIFF
--- a/lib/ClusterShell/Communication.py
+++ b/lib/ClusterShell/Communication.py
@@ -47,6 +47,8 @@ try:
 except ImportError:  # Python 2 compat
     import cPickle
 
+from pickle import HIGHEST_PROTOCOL
+
 import base64
 import binascii
 import logging
@@ -74,6 +76,10 @@ ENCODING = 'utf-8'
 
 # See Message.data_encode()
 DEFAULT_B64_LINE_LENGTH = 65536
+
+# Gateway messages may cross Python versions within a tree: cap the pickle
+# protocol at 4, readable since Python 3.4 (Python 2 writes protocol 2)
+GW_PICKLE_PROTOCOL = min(HIGHEST_PROTOCOL, 4)
 
 
 class MessageProcessingError(Exception):
@@ -298,7 +304,7 @@ class Message(object):
         # Base64 transfer encoding for MIME mandates a fixed line length
         # of 76 characters, which is way too small for our per-line ev_read
         # mechanism. So use b64encode() here instead of encodestring().
-        encoded = base64.b64encode(cPickle.dumps(inst))
+        encoded = base64.b64encode(cPickle.dumps(inst, GW_PICKLE_PROTOCOL))
 
         # We now follow relaxed RFC-4648 for base64, but we still add some
         # newlines to very long lines to avoid memory pressure (eg. --rcopy).
@@ -316,10 +322,11 @@ class Message(object):
         # if self.data is None then an exception is raised here
         try:
             return cPickle.loads(base64.b64decode(self.data))
-        except (EOFError, TypeError, cPickle.UnpicklingError, binascii.Error):
+        except (EOFError, TypeError, ValueError, cPickle.UnpicklingError,
+                binascii.Error) as exc:
             # raised by cPickle.loads() if self.data is not valid
             raise MessageProcessingError('Message %s has an invalid payload'
-                                         % self.ident)
+                                         ' (%s)' % (self.ident, exc))
 
     def data_update(self, raw):
         """append data to the instance (used for deserialization)"""

--- a/lib/ClusterShell/RangeSet.py
+++ b/lib/ClusterShell/RangeSet.py
@@ -337,7 +337,8 @@ class RangeSet(set):
 
     def __reduce__(self):
         """Return state information for pickling."""
-        return self.__class__, (str(self),), \
+        pattern = str(self) if self else None  # RangeSet("") raises by design
+        return self.__class__, (pattern,), \
             { 'padding': self.padding, \
               '_autostep': self._autostep, \
               '_version' : RangeSet._VERSION }

--- a/lib/ClusterShell/Worker/Tree.py
+++ b/lib/ClusterShell/Worker/Tree.py
@@ -201,9 +201,9 @@ class TreeWorker(DistantWorker):
                 invoke_gw_args.append("%s=%s" % (envname, envval))
 
         # It is critical to launch a remote Python executable with the same
-        # major version (ie. python or python3) as we use the (default) pickle
-        # protocol and for example, version 3+ (Python 3 with bytes
-        # support) cannot be unpickled by Python 2.
+        # major version (ie. python or python3): the pickle protocol used
+        # for gateway messages is pinned (Communication.GW_PICKLE_PROTOCOL)
+        # but still differs between Python 2 and Python 3.
         python_executable = os.getenv('CLUSTERSHELL_GW_PYTHON_EXECUTABLE',
                                       basename(sys.executable or 'python'))
         invoke_gw_args.append(python_executable)

--- a/tests/RangeSetTest.py
+++ b/tests/RangeSetTest.py
@@ -4,6 +4,7 @@
 """Unit test for RangeSet"""
 
 import binascii
+import copy
 import pickle
 import unittest
 import warnings
@@ -1106,6 +1107,21 @@ class RangeSetTest(unittest.TestCase):
         self.assertEqual(rngset[0], '1')
         self.assertEqual(rngset[1], '2')
         self.assertEqual(rngset[-1], '100')
+
+    def test_pickle_empty(self):
+        """test empty RangeSet pickling"""
+        rngset = pickle.loads(pickle.dumps(RangeSet(autostep=3)))
+        self.assertEqual(rngset, RangeSet())
+        self.assertEqual(str(rngset), "")
+        self.assertEqual(len(rngset), 0)
+        self.assertEqual(rngset.autostep, 3)
+
+    def test_deepcopy_empty(self):
+        """test empty RangeSet deepcopy (uses __reduce__ too)"""
+        rngset = copy.deepcopy(RangeSet())
+        self.assertEqual(rngset, RangeSet())
+        self.assertEqual(str(rngset), "")
+        self.assertEqual(len(rngset), 0)
 
     def testIntersectionLength(self):
         """test RangeSet intersection/length"""

--- a/tests/TreeGatewayTest.py
+++ b/tests/TreeGatewayTest.py
@@ -2,6 +2,7 @@
 Unit test for ClusterShell.Gateway
 """
 
+import base64
 import logging
 import os
 import re
@@ -318,7 +319,7 @@ class TreeGatewayTest(TreeGatewayBaseTest):
         """test gateway channel message missing payload"""
         self._check_channel_err(
             '<message msgid="14" type="CFG" gateway="n1"></message>',
-            'Message CFG has an invalid payload')
+            re.compile(r'Message CFG has an invalid payload'))
 
     def test_channel_err_unexpected_pl(self):
         """test gateway channel message unexpected payload"""
@@ -331,14 +332,23 @@ class TreeGatewayTest(TreeGatewayBaseTest):
         # Generate TypeError (py2) or binascii.Error (py3)
         self._check_channel_err(
             '<message msgid="14" type="CFG" gateway="n1">bar</message>',
-            'Message CFG has an invalid payload')
+            re.compile(r'Message CFG has an invalid payload'))
 
     def test_channel_err_badenc_pickle_pl(self):
         """test gateway channel message badly encoded payload (pickle)"""
         # Generate pickle error
         self._check_channel_err(
             '<message msgid="14" type="CFG" gateway="n1">barm</message>',
-            'Message CFG has an invalid payload')
+            re.compile(r'Message CFG has an invalid payload'))
+
+    def test_channel_err_pickle_proto_pl(self):
+        """test gateway channel message payload with unknown pickle protocol"""
+        # Generate ValueError (unsupported pickle protocol: 7)
+        payload = base64.b64encode(b'\x80\x07spam').decode()
+        self._check_channel_err(
+            '<message msgid="14" type="CFG" gateway="n1">%s</message>'
+            % payload,
+            re.compile(r'Message CFG has an invalid payload'))
 
     def test_channel_basic_abort(self):
         """test gateway channel aborted while opened"""
@@ -492,3 +502,17 @@ class TreeGatewayTest(TreeGatewayBaseTest):
         """test gateway channel write multi (remote=False)"""
         self._check_channel_ctl_shell("cat", "n[10-49]", True, False,
                                       StdOutMessage, b"ok", write_buf=b"ok\n")
+
+
+class TreeMessageTest(unittest.TestCase):
+    """test tree communication messages (no gateway needed)"""
+
+    def test_msg_pickle_protocol(self):
+        """test message payload pickle protocol pin (wire format)"""
+        msg = ConfigurationMessage('n1')
+        msg.data_encode({'foo': 'bar'})
+        raw = base64.b64decode(msg.data)
+        # pickle protocol 2+ starts with PROTO opcode then protocol number
+        self.assertEqual(raw[0:1], b'\x80')
+        self.assertLessEqual(bytearray(raw)[1], 4)  # bytearray for py2 compat
+        self.assertEqual(msg.data_decode(), {'foo': 'bar'})


### PR DESCRIPTION
Tree mode pickles gateway messages with the default pickle protocol. Python 3.14 bumped the default to protocol 5, unreadable by Python < 3.8, so a tree mixing a py3.14+ node with a py3.6/3.7 node (e.g. EL8) breaks in either direction (commands down, results up).

- Pin the gateway message pickle protocol to `min(pickle.HIGHEST_PROTOCOL, 4)` — readable since Python 3.4 (protocol 2 on Python 2, up from 0). This only changes what a node writes; no supported pairing regresses and mixed py2/py3 trees remain unsupported as before.
- Catch `ValueError` in `Message.data_decode()` (a too-new protocol raises `ValueError`, not `UnpicklingError`, and escaped as a raw traceback) and include the cause in `MessageProcessingError`.
- Fix unpickling of empty `RangeSet` objects: `__reduce__()` used `str(self)`, but `RangeSet("")` raises by design, so empty sets (also embedded in `NodeSetBase`/unfolded `RangeSetND` pickles) could be pickled but never unpickled.

Tested on Python 2.7, 3.13 and 3.14 (Tree/Gateway/RangeSet/NodeSet test modules).