### PR TITLE
NodeSet: fix stepped slice across multiple patterns

### DIFF
--- a/lib/ClusterShell/NodeSet.py
+++ b/lib/ClusterShell/NodeSet.py
@@ -446,7 +446,7 @@ class NodeSetBase(object):
                 sl_next += num
                 if (sl_next - sl_start) % sl_step:
                     sl_next = sl_start + \
-                        ((sl_next - sl_start)/sl_step + 1) * sl_step
+                        ((sl_next - sl_start)//sl_step + 1) * sl_step
                 if sl_next >= sl_stop:
                     break
                 length += cnt

--- a/tests/NodeSetTest.py
+++ b/tests/NodeSetTest.py
@@ -1221,6 +1221,11 @@ class NodeSetTest(unittest.TestCase):
         self.assertEqual(str(nodeset[8:10]), "stone9,wood1")
         self.assertEqual(str(nodeset[9:10]), "wood1")
         self.assertEqual(str(nodeset[9:]), "wood[1-9]")
+        # multiple patterns with stepped slices
+        self.assertEqual(str(nodeset[::2]), "stone[1,3,5,7,9],wood[2,4,6,8]")
+        self.assertEqual(str(nodeset[1::2]), "stone[2,4,6,8],wood[1,3,5,7,9]")
+        self.assertEqual(str(nodeset[2:15:4]), "stone[3,7],wood[2,6]")
+        self.assertEqual(str(nodeset[::-2]), "stone[2,4,6,8],wood[1,3,5,7,9]")
         nodeset = NodeSet("stone[1-9],water[10-12],wood[1-9]")
         self.assertEqual(str(nodeset[8:10]), "stone9,water10")
         self.assertEqual(str(nodeset[11:15]), "water12,wood[1-3]")
@@ -1229,6 +1234,7 @@ class NodeSetTest(unittest.TestCase):
         self.assertEqual(str(nodeset[8:11]), "stone9,water,wood1")
         self.assertEqual(str(nodeset[9:11]), "water,wood1")
         self.assertEqual(str(nodeset[9:12]), "water,wood[1-2]")
+        self.assertEqual(str(nodeset[8::2]), "stone9,wood[1,3,5,7,9]")
 
     def test_bad_slices(self):
         nodeset = NodeSet("cluster[1-30]c[1-2]")


### PR DESCRIPTION
Bugfix for 1.10.1, found while auditing Python 2 leftovers:
- `NodeSet("a[0-2],b[0-2]")[::2]` raises `TypeError: slice indices must be integers` on Python 3: the next-slice-index computation (unchanged since 2010) uses Python 2 division. Triggers whenever a stepped slice spans multiple patterns with a step remainder.
- Fix is floor division; results verified identical to slicing the flat node list.
- Added multi-pattern stepped-slice cases to `test_getslice` (existing slice cases were all single-pattern, which is why this went unnoticed).
- Risk: very low — one-character fix on the only affected path, which could only crash before. Also verified on Python 2.7 (EL7 VM).
