### PR TITLE
Engine: fix error handling in EPoll and Select event loops

### DIFF
--- a/lib/ClusterShell/Engine/EPoll.py
+++ b/lib/ClusterShell/Engine/EPoll.py
@@ -125,6 +125,7 @@ class EngineEPoll(Engine):
                 # might get interrupted by a signal
                 if ex.errno == errno.EINTR:
                     continue
+                raise
 
             for fd, event in evlist:
 

--- a/lib/ClusterShell/Engine/Select.py
+++ b/lib/ClusterShell/Engine/Select.py
@@ -27,6 +27,7 @@ The select() system call is available on almost every UNIX-like systems.
 """
 
 import errno
+import logging
 import select
 import sys
 import time

--- a/tests/EngineErrorTest.py
+++ b/tests/EngineErrorTest.py
@@ -1,0 +1,51 @@
+"""
+Unit test for Engine event loop error handling
+"""
+
+import errno
+import select
+import unittest
+
+import ClusterShell.Engine.Select
+from ClusterShell.Engine.Engine import EngineNotSupportedError
+from ClusterShell.Engine.EPoll import EngineEPoll
+from ClusterShell.Engine.Select import EngineSelect
+
+
+class EngineErrorTest(unittest.TestCase):
+    """test that non-EINTR event loop errors propagate"""
+
+    def test_epoll_error(self):
+        """test EPoll engine non-EINTR error propagation"""
+        try:
+            engine = EngineEPoll({})
+        except EngineNotSupportedError:
+            self.skipTest("engine epoll not supported on this host")
+
+        class BadPoller(object):
+            def poll(self, *args):
+                raise IOError(errno.EBADF, "injected error")
+
+        engine.epolling.close()
+        engine.epolling = BadPoller()
+        engine.evlooprefcnt = 1
+        self.assertRaises(IOError, engine.runloop, None)
+
+    def test_select_error(self):
+        """test Select engine non-EINTR error propagation"""
+        engine = EngineSelect({})
+
+        class BadSelect(object):
+            error = select.error
+
+            @staticmethod
+            def select(*args):
+                raise select.error(errno.EINVAL, "injected error")
+
+        select_mod = ClusterShell.Engine.Select.select
+        ClusterShell.Engine.Select.select = BadSelect
+        try:
+            engine.evlooprefcnt = 1
+            self.assertRaises(select.error, engine.runloop, None)
+        finally:
+            ClusterShell.Engine.Select.select = select_mod


### PR DESCRIPTION
Bugfix for 1.10.1, found while auditing Python 2 leftovers. Two latent bugs in engine event loop error handling; the Poll engine already does both things right, this aligns EPoll and Select with it:
- EPoll: the `except IOError` clause only handled EINTR and swallowed every other poll error, after which the loop reused a stale or unbound `evlist` (`UnboundLocalError` on first iteration). Real errors now propagate to `Engine.run` cleanup, like in Poll.
- Select: the `EINVAL/EBADF/ENOMEM` diagnostic called `logging.getLogger()` but Select.py never imported `logging` — a guaranteed `NameError` masking the real error.
- New `EngineErrorTest` injects poll/select failures directly: without the fixes it reproduces the `UnboundLocalError`/`NameError`, with them the original `OSError` propagates.
- Risk: very low — only already-broken error paths change; the happy path is untouched. Also verified on Python 2.7 (EL7 VM), where the EINTR retry is kept.
