### PR TITLE
Tree: fix rcopy extraction error reporting

### DIFF
--- a/lib/ClusterShell/Worker/Tree.py
+++ b/lib/ClusterShell/Worker/Tree.py
@@ -468,15 +468,19 @@ class TreeWorker(DistantWorker):
                     tarfileobj.write(buf)
                 tarfileobj.flush()
                 tarfileobj.seek(0)
-                tmptar = tarfile.open(fileobj=tarfileobj)
+                tmptar = None
                 try:
+                    tmptar = tarfile.open(fileobj=tarfileobj)
                     self.logger.debug("%s extracting %d members in dest %s",
                                       node, len(tmptar.getmembers()), self.dest)
                     tmptar.extractall(path=self.dest, **_TAR_EXTRACT_KWARGS)
-                except IOError as ex:
-                    self._on_remote_node_msgline(node, ex, 'stderr', gateway)
+                # see PEP 3151
+                except (IOError, OSError, tarfile.TarError) as ex:
+                    self._on_remote_node_msgline(node, str(ex).encode(),
+                                                 'stderr', gateway)
                 finally:
-                    tmptar.close()
+                    if tmptar is not None:
+                        tmptar.close()
                 del self._rcopy_bufs[node]
                 del self._rcopy_tars[node]
             else:

--- a/tests/TreeWorkerTest.py
+++ b/tests/TreeWorkerTest.py
@@ -333,6 +333,37 @@ class TreeWorkerTestBase(unittest.TestCase):
             srcdir.cleanup()
             destdir.cleanup()
 
+    def _tree_rcopy_dir_error(self, target):
+        """helper to rcopy directory to a bad dest (extract error -> stderr)"""
+        teh = TEventHandler()
+        srcdir = make_temp_dir()
+        srcfile = make_temp_file(b'Lorem Ipsum', suffix=".txt", dir=srcdir.name)
+        destdir = make_temp_dir()
+        # conflicting regular files at extract paths so untar always fails
+        for tgt in NodeSet(target):
+            conflict = join(destdir.name, basename(srcdir.name) + '.' + tgt)
+            with open(conflict, 'wb') as cfile:
+                cfile.write(b'conflict')
+        try:
+            worker = self.task.rcopy(srcdir.name, destdir.name, nodes=target,
+                                     handler=teh)
+            self.task.run()
+            target_cnt = len(NodeSet(target))
+            self.assertEqual(teh.ev_start_cnt, 1)
+            self.assertEqual(teh.ev_pickup_cnt, target_cnt)
+            self.assertEqual(teh.ev_hup_cnt, target_cnt)
+            self.assertEqual(teh.ev_timedout_cnt, 0)
+            self.assertEqual(teh.ev_close_cnt, 1)
+            # the rcopy failed: extract error must be reported as stderr
+            self.assertTrue(teh.ev_read_cnt > 0)
+            self.assertEqual(teh.read_snames, set([worker.SNAME_STDERR]))
+            # as bytes, like any other message (not the exception object)
+            self.assertTrue(isinstance(teh.last_read, bytes))
+        finally:
+            srcfile.close()
+            srcdir.cleanup()
+            destdir.cleanup()
+
 
 @unittest.skipIf(HOSTNAME == 'localhost', "does not work with hostname set to 'localhost'")
 class TreeWorkerTest(TreeWorkerTestBase):
@@ -634,6 +665,18 @@ class TreeWorkerTest(TreeWorkerTestBase):
     def test_tree_rcopy_file_foreign(self):
         """test tree rcopy: file, direct target, not in topology"""
         self._tree_rcopy_file(NODE_FOREIGN)
+
+    def test_tree_rcopy_dir_error_direct(self):
+        """test tree rcopy: bad dest, direct target -> stderr"""
+        self._tree_rcopy_dir_error(NODE_DIRECT)
+
+    def test_tree_rcopy_dir_error_distant(self):
+        """test tree rcopy: bad dest, distant target via gateway -> stderr"""
+        self._tree_rcopy_dir_error(NODE_DISTANT)
+
+    def test_tree_rcopy_dir_error_distant2(self):
+        """test tree rcopy: bad dest, distant 2 targets via gateway -> stderr"""
+        self._tree_rcopy_dir_error(NODE_DISTANT2)
 
     def test_tree_rcopy_no_tarfile_warning(self):
         """test tree rcopy: no tarfile warning leaks (PEP 706, <3.14 compat)"""


### PR DESCRIPTION
Bugfix for 1.10.1, found while auditing Python 2 leftovers. When rcopy tar extraction fails on the head node, the error report path was broken in several ways:
- `_on_remote_node_close` passed the exception object where a bytes msgline is expected, crashing the first consumer that touches it (clush: `AttributeError` in `Display.print_line_error`; library `MsgTree.add`: `TypeError`) and masking the real error. It now reports `str(ex).encode()`.
- The catch is broadened to `(IOError, OSError, tarfile.TarError)` (the PEP 3151 pattern already used elsewhere in the codebase): on Python 2, directory creation during extraction raises `OSError`, and corrupt tar payloads raise `TarError` on both Pythons — all previously escaped the handler and crashed the worker. `tarfile.open` also moves inside the `try` so open errors (e.g. truncated header) are reported the same way.
- New `_tree_rcopy_dir_error` tests (direct/distant/distant2 targets), mirroring the #622 bad-dest copy tests; the distant variants fail without the fix.
- Risk: low — error-path only, and that path could not succeed before. Verified on Python 2.7 (EL7 VM, TreeWorkerTest 71/71), where the new tests exercise the Python 2 `OSError` branch specifically.

Before/after with `clush --topology=... -w 127.0.0.2 --rcopy /path/src --dest /path/dest` where `dest/src.127.0.0.2` already exists as a regular file:

Before — clush exits 1 with 200 lines of nested tracebacks (starting with `Error in sys.excepthook:`), the cause buried:
```
  File ".../CLI/Display.py", line 229, in print_line_error
    linestr = line.decode(STRING_ENCODING, errors='replace') + '\n'
AttributeError: 'FileExistsError' object has no attribute 'decode'
```

After:
```
127.0.0.2: [Errno 17] File exists: '/path/dest/src.127.0.0.2'
```
