### PR TITLE
tests: add gateway reply timeout in TreeGatewayTest

### DIFF
--- a/tests/TreeGatewayTest.py
+++ b/tests/TreeGatewayTest.py
@@ -6,6 +6,7 @@ import base64
 import logging
 import os
 import re
+import select
 import unittest
 import xml.sax
 
@@ -24,6 +25,9 @@ from .TLib import HOSTNAME
 
 # enable live DEBUG logging when running the tests
 logging.basicConfig(level=logging.DEBUG)
+
+# max time (secs) to wait for a gateway reply before failing the test
+RECV_TIMEOUT = 30
 
 
 class Gateway(object):
@@ -60,7 +64,9 @@ class Gateway(object):
         self.send(msgstr.encode())
 
     def recv(self):
-        """recv buf from pseudo stdout (blocking call)"""
+        """recv buf from pseudo stdout (blocking call with timeout)"""
+        if not select.select([self.pipe_stdout[0]], [], [], RECV_TIMEOUT)[0]:
+            raise RuntimeError("no gateway reply after %ds" % RECV_TIMEOUT)
         return os.read(self.pipe_stdout[0], 4096)
 
     def wait(self):


### PR DESCRIPTION
`Gateway.recv()` in TreeGatewayTest blocked forever in `os.read()` when the
in-process gateway never replied, eating the whole suite timeout with no
traceback. `recv()` now waits with `select()` (30s) and raises a clear
`RuntimeError`; the remaining tests still run.

Context: the hang is real and specific to EL9 (RHEL/Rocky 9). The test feeds
raw `os.read()` chunks to its incremental SAX parser, so when a read races
between the gateway's chunked writes of the `<channel ...>` start tag, the
split token hits expat's reparse deferral (see #556) and is never parsed —
the protocol is request-reply, so no further bytes arrive. The
`parser.flush()` rescue from #556/#569 works with upstream expat >= 2.6.0,
but EL9's expat 2.5.0 backports the deferral while leaving
`XML_SetReparseDeferralEnabled()` a no-op, so CPython's `flush()` is
silently ineffective there with any Python version (reproduced with
RHEL-built 3.9/3.11/3.12; deterministic with 1-byte reads).

The library itself is not affected: `Channel.ev_read()` feeds complete
worker-framed lines to the parser, so tokens never span `feed()` calls.
The test's raw-chunk feeding is kept on purpose — it usefully surfaces the
platform issue, now at a 30s cost instead of a suite hang.
