### PR TITLE
doc: explain DNS domain suffix stripping for Ansible bindings

### DIFF
--- a/conf/groups.conf.d/ansible.conf.example
+++ b/conf/groups.conf.d/ansible.conf.example
@@ -10,6 +10,9 @@
 # Replace /path/to/inventory with your inventory path or directory,
 # or set ANSIBLE_INVENTORY in your environment to override it.
 #
+# Hostnames can be post-processed in jq, for instance to strip a DNS domain
+# suffix; see the Ansible inventory bindings section of the online docs.
+#
 [ansible]
 
 # Resolve group members, recursing into child groups

--- a/doc/sphinx/config.rst
+++ b/doc/sphinx/config.rst
@@ -756,6 +756,12 @@ aliases (e.g. with dynamic inventory) are not directly usable with
 :ref:`clush-tool`. These commands can be adapted to your inventory as needed,
 for instance to emit ``ansible_host`` instead.
 
+Another common adaptation is to strip a DNS domain suffix when the inventory
+contains fully qualified hostnames but short names resolve on the cluster.
+Append ``| sub("\\.example\\.com$"; "")`` to the ``map`` and ``all`` filters,
+and in ``mapall``, apply it to each hostname by changing ``[r($d;.)]`` to
+``[r($d;.) | sub("\\.example\\.com$"; "")]``.
+
 The ``mapall`` upcall resolves every group in a single ``ansible-inventory
 --list`` call. As ``--list`` always dumps the whole inventory regardless of the
 group being queried, this avoids running one ``ansible-inventory`` command per


### PR DESCRIPTION
When `ansible-inventory` returns fully qualified hostnames, `nodeset`/`cluset`/`clush` output is more verbose than needed on clusters where short names resolve.

- `config.rst`: document how to strip a DNS domain suffix in the jq filters, in the same spirit as the existing `ansible_host` adaptation note
- `ansible.conf.example`: add a pointer comment (upcalls unchanged)