### PR TITLE
doc: enable sphinx.ext.viewcode

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -25,7 +25,8 @@ sys.path.insert(0, os.path.abspath('../../lib'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx_rtd_theme', 'sphinxcontrib.asciinema']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx_rtd_theme',
+              'sphinxcontrib.asciinema']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Add `sphinx.ext.viewcode` to the Sphinx extensions: each documented class/function in the [API docs](https://clustershell.readthedocs.io/en/latest/api/index.html) gets a `[source]` link to a syntax-highlighted rendering of the module source. Bundled with Sphinx — no new dependency, no change to the documented API surface.

Restores the source-browsing feature of the retired epydoc docs (see #667).