### PR TITLE
doc: modernize Sphinx build requirements

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -136,13 +136,7 @@ def setup(app):
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
 # Better to disable this to prevent alteration of command-line arguments
-# Sphinx <1.6 use `html_use_smartypants` and >=1.6 use `smartquotes`
-from sphinx import __version__ as sphinx_version
-sphinx_version_parts = [int(i) for i in sphinx_version.split('.')]
-if sphinx_version_parts[0] <= 1 and sphinx_version_parts[1] < 6:
-    html_use_smartypants = False
-else:
-    smartquotes = False
+smartquotes = False
 
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}

--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -1,7 +1,3 @@
-sphinx==6.2.1
-sphinx-rtd-theme==1.2.2
-pillow==12.2.0
-mock==1.0.1
-commonmark==0.9.1
-recommonmark==0.5.0
-sphinxcontrib.asciinema==0.4.2
+sphinx==9.1.0
+sphinx-rtd-theme==3.1.0
+sphinxcontrib.asciinema==0.4.3


### PR DESCRIPTION
Modernize `doc/sphinx/requirements.txt`, used by both the ReadTheDocs build and the `sphinx` CI check:

- bump `sphinx` 6.2.1 → 9.1.0, `sphinx-rtd-theme` 1.2.2 → 3.1.0, `sphinxcontrib.asciinema` 0.4.2 → 0.4.3
- drop unused pins: `mock`, `commonmark`, `recommonmark` (no Markdown sources), `pillow`
- conf.py: drop the Sphinx <1.6 smartquotes compat shim, keep `smartquotes = False`

Verified beyond CI: `-W` build with the new pins produces the same HTML page set as 6.2.1; viewcode `[source]`/`[docs]` links, asciinema player, and literal `--option` strings (smartquotes off) all intact.