### PR TITLE
Communication: fix TypeError when reporting channel errors

### DIFF
--- a/lib/ClusterShell/Communication.py
+++ b/lib/ClusterShell/Communication.py
@@ -244,7 +244,7 @@ class Channel(EventHandler):
             self.logger.error("SAXParseException: %s: %s", ex.getMessage(), msg)
             # Warning: do not send malformed raw message back
             if self.initiator:
-                self.recv(StdErrMessage(node, ex.getMessage()))
+                self.recv(StdErrMessage(node, ex.getMessage().encode(ENCODING)))
             else:
                 # target, not initiator: we can send an error message back
                 self.send(ErrorMessage('Parse error: %s' % ex.getMessage()))
@@ -255,7 +255,7 @@ class Channel(EventHandler):
             self.logger.error("MessageProcessingError: %s (initiator=%s)",
                               ex, self.initiator)
             if self.initiator:
-                self.recv(StdErrMessage(node, str(ex)))
+                self.recv(StdErrMessage(node, str(ex).encode(ENCODING)))
             else:
                 # target, not initiator: we can send an error message back
                 self.send(ErrorMessage(str(ex)))

--- a/tests/TreeGatewayTest.py
+++ b/tests/TreeGatewayTest.py
@@ -16,6 +16,7 @@ from ClusterShell.Communication import ConfigurationMessage, ControlMessage, \
     TimeoutMessage, StartMessage, EndMessage, XMLReader
 from ClusterShell.Gateway import GatewayChannel
 from ClusterShell.NodeSet import NodeSet
+from ClusterShell.Propagation import PropagationChannel
 from ClusterShell.Task import Task, task_self
 from ClusterShell.Topology import TopologyGraph
 from ClusterShell.Worker.Tree import TreeWorker
@@ -522,3 +523,67 @@ class TreeMessageTest(unittest.TestCase):
         self.assertEqual(raw[0:1], b'\x80')
         self.assertLessEqual(bytearray(raw)[1], 4)  # bytearray for py2 compat
         self.assertEqual(msg.data_decode(), {'foo': 'bar'})
+
+
+class ChannelWorkerStub(object):
+    """stub channel worker for head-side channel tests"""
+
+    def __init__(self):
+        self.aborted = False
+
+    def write(self, buf, sname=None):
+        return len(buf)
+
+    def abort(self):
+        self.aborted = True
+
+
+class MetaWorkerStub(object):
+    """stub metaworker recording remote node messages"""
+
+    def __init__(self):
+        self.msglines = []
+
+    def _on_remote_node_msgline(self, node, msg, sname, gateway):
+        self.msglines.append((node, msg, sname, gateway))
+
+
+class TreeHeadChannelErrorTest(unittest.TestCase):
+    """test head-side (initiator) channel errors (no gateway needed)"""
+
+    def setUp(self):
+        self.chan = PropagationChannel(task_self(), 'gw1')
+        self.chan.worker = ChannelWorkerStub()
+        self.mw = MetaWorkerStub()
+        self.chan.workers[id(self.mw)] = self.mw
+        # gateway greeting opens the channel
+        self.chan.ev_read(self.chan.worker, 'gw1', self.chan.SNAME_READER,
+                          ('<channel version="%s">' % __version__).encode())
+        self.assertTrue(self.chan.opened)
+
+    def test_head_channel_err_invalid_tag(self):
+        """test head channel invalid tag reported as stderr"""
+        self.chan.ev_read(self.chan.worker, 'gw1', self.chan.SNAME_READER,
+                          b'<foo></foo>')
+        [(node, msg, sname, gateway)] = self.mw.msglines
+        self.assertEqual(node, 'gw1')
+        self.assertEqual(msg, b'Invalid starting tag foo')
+        self.assertEqual(sname, 'stderr')
+        self.assertEqual(gateway, 'gw1')
+        # fatal channel error: channel must be closed
+        self.assertTrue(self.chan.worker.aborted)
+        self.assertFalse(self.chan.opened)
+
+    def test_head_channel_err_parse_error(self):
+        """test head channel parse error reported as stderr"""
+        self.chan.ev_read(self.chan.worker, 'gw1', self.chan.SNAME_READER,
+                          b'<message type="ABC"</message>')
+        [(node, msg, sname, gateway)] = self.mw.msglines
+        self.assertEqual(node, 'gw1')
+        self.assertTrue(isinstance(msg, bytes))
+        self.assertIn(b'not well-formed', msg)
+        self.assertEqual(sname, 'stderr')
+        self.assertEqual(gateway, 'gw1')
+        # fatal channel error: channel must be closed
+        self.assertTrue(self.chan.worker.aborted)
+        self.assertFalse(self.chan.opened)


### PR DESCRIPTION
When a gateway sends invalid data on the channel (malformed XML or an invalid
message), the head node crashes with a `TypeError` instead of reporting the
error, so the user sees:

```
clush: target1: exited with exit code 76
clush: can only concatenate str (not "bytes") to str
```

`Channel.ev_read()` builds the error report as `str`, while every other
`StdErrMessage` producer passes bytes and `PropagationChannel.recv()` decodes
payloads as bytes (this worked on Python 2, where `str` is bytes). The escaping
`TypeError` also skips `_close()`, leaving the channel worker running.

- encode error text at both `ev_read()` error sites, like other `StdErrMessage` producers
- add head-side (initiator) channel error tests covering both branches

With the fix, the same failure reports the actual error, attributed to the
gateway node:

```
localhost: Invalid starting tag foo
clush: target1: exited with exit code 76
```

Found while analyzing #672: a gateway rejecting an unsupported protocol version
would have its error text lost on the head node. Same bug class as #663.
Also verified on Python 2.7 (CentOS 7).
