### PR TITLE
Tree: report gateway errors received before channel setup

### DIFF
--- a/lib/ClusterShell/Propagation.py
+++ b/lib/ClusterShell/Propagation.py
@@ -35,6 +35,7 @@ from ClusterShell.Communication import (Channel, ControlMessage, StdOutMessage,
                                         RoutedMessageBase, ErrorMessage,
                                         ConfigurationMessage, TimeoutMessage,
                                         RoutingMessage)
+from ClusterShell.Communication import ENCODING
 from ClusterShell.Topology import TopologyError
 
 
@@ -260,6 +261,17 @@ class PropagationChannel(Channel):
         cfg.data_encode(self.task.topology)
         self.send(cfg)
 
+    def _report_stderr(self, nodeset, buf):
+        """report buf as stderr of nodeset, as seen from the gateway"""
+        # trailing newline: splitlines() would drop an empty buf entirely (#249)
+        lines = (buf + b'\n').splitlines()
+
+        for metaworker in self.workers.values():
+            for line in lines:
+                for node in nodeset:
+                    metaworker._on_remote_node_msgline(node, line, 'stderr',
+                                                       self.gateway)
+
     def recv(self, msg):
         """process incoming messages"""
         self.logger.debug("recv: %s", msg)
@@ -269,14 +281,7 @@ class PropagationChannel(Channel):
         elif msg.type == StdErrMessage.ident and msg.srcid == 0:
             # Handle error messages when channel is not established yet
             # or if messages are non-routed (eg. gateway-related)
-            nodeset = NodeSet(msg.nodes)
-            decoded = msg.data_decode() + b'\n'
-
-            for metaworker in self.workers.values():
-                for line in decoded.splitlines():
-                    for node in nodeset:
-                        metaworker._on_remote_node_msgline(node, line, 'stderr',
-                                                           self.gateway)
+            self._report_stderr(NodeSet(msg.nodes), msg.data_decode())
         elif self.setup:
             self.recv_ctl(msg)
         elif self.opened:
@@ -350,6 +355,10 @@ class PropagationChannel(Channel):
             self.logger.debug("CTL - connection with gateway fully established")
             self.setup = True
             self.send_dequeue()
+        elif msg.type == ErrorMessage.ident:
+            # gateway error before setup (eg. invalid CFG payload)
+            self._report_stderr(NodeSet(self.gateway),
+                                msg.reason.encode(ENCODING))
         else:
             self.logger.debug("_state_config error (msg=%s)", msg)
 

--- a/tests/TreeGatewayTest.py
+++ b/tests/TreeGatewayTest.py
@@ -18,7 +18,7 @@ from ClusterShell.Gateway import GatewayChannel
 from ClusterShell.NodeSet import NodeSet
 from ClusterShell.Propagation import PropagationChannel
 from ClusterShell.Task import Task, task_self
-from ClusterShell.Topology import TopologyGraph
+from ClusterShell.Topology import TopologyError, TopologyGraph
 from ClusterShell.Worker.Tree import TreeWorker
 from ClusterShell.Worker.Worker import StreamWorker
 
@@ -587,3 +587,34 @@ class TreeHeadChannelErrorTest(unittest.TestCase):
         # fatal channel error: channel must be closed
         self.assertTrue(self.chan.worker.aborted)
         self.assertFalse(self.chan.opened)
+
+    def test_head_channel_gw_error_before_setup(self):
+        """test gateway error before setup reported as stderr"""
+        self.chan.ev_read(self.chan.worker, 'gw1', self.chan.SNAME_READER,
+                          b'<message type="ERR" msgid="0" reason="Message CFG '
+                          b'has an invalid payload (unsupported pickle '
+                          b'protocol: 5)"></message>')
+        [(node, msg, sname, gateway)] = self.mw.msglines
+        self.assertEqual(node, 'gw1')
+        self.assertEqual(msg, b'Message CFG has an invalid payload'
+                              b' (unsupported pickle protocol: 5)')
+        self.assertEqual(sname, 'stderr')
+        self.assertEqual(gateway, 'gw1')
+
+    def test_head_channel_gw_error_empty_reason(self):
+        """test gateway error with empty reason reported as empty line"""
+        self.chan.ev_read(self.chan.worker, 'gw1', self.chan.SNAME_READER,
+                          b'<message type="ERR" msgid="0" reason=""></message>')
+        self.assertEqual(self.mw.msglines, [('gw1', b'', 'stderr', 'gw1')])
+
+    def test_head_channel_gw_error_after_setup(self):
+        """test gateway error after setup raises TopologyError"""
+        # gateway ACK completes channel setup
+        self.chan.ev_read(self.chan.worker, 'gw1', self.chan.SNAME_READER,
+                          b'<message type="ACK" msgid="0" ack="0"></message>')
+        self.assertTrue(self.chan.setup)
+        self.assertRaises(TopologyError, self.chan.ev_read, self.chan.worker,
+                          'gw1', self.chan.SNAME_READER,
+                          b'<message type="ERR" msgid="1" reason="bad news">'
+                          b'</message>')
+        self.assertEqual(self.mw.msglines, [])


### PR DESCRIPTION
A gateway that fails before channel setup does report why — the head just drops it. All the user gets:

```
clush: target1: exited with exit code 76
```

With this fix:

```
localhost: Message CFG has an invalid payload (unsupported pickle protocol: 5)
clush: target1: exited with exit code 76
```

`PropagationChannel.recv_cfg()` debug-logs any non-ACK message and drops it, so every pre-setup gateway error is lost — protocol-level rejections, and `CFG` decode failures like the #658 case (newer head, protocol-5 pickles, older gateway). The gateway only logs the reason to a file on itself, so nothing else surfaces it.

The reason is now reported as stderr of the gateway node; nothing else changes (same per-target rc 76, same `clush -S` exit code). Failing just that gateway, rather than raising `TopologyError` as `recv_ctl()` does after setup, keeps the rest of the run alive and matches `ev_close()`, which already redistributes pre-setup channel failures per gateway. Chained gateways work too, attributed to the gateway that actually rejected.

Also verified on Python 2.7 (CentOS 7).

Follow-up to #673.

See #672: a gateway rejecting an unsupported protocol version would report it through this same path, so the check proposed there depends on this fix.
