### PR TITLE
tests: fix race in testThreadTaskUnhandledException

### DIFF
--- a/tests/TaskThreadJoinTest.py
+++ b/tests/TaskThreadJoinTest.py
@@ -108,15 +108,19 @@ class TaskThreadJoinTest(unittest.TestCase):
         class TestUnhandledException(Exception):
             """test exception"""
         class RaiseOnRead(EventHandler):
+            def __init__(self):
+                self.msg = None
             def ev_read(self, worker, node, sname, msg):
+                self.msg = msg
                 raise TestUnhandledException("you should see this exception")
 
         task = Task()
-        # test data access from main thread
-        task.shell("echo raisefoobar", key=1, handler=RaiseOnRead())
+        eh = RaiseOnRead()
+        task.shell("echo raisefoobar", key=1, handler=eh)
         task.resume()
         task.join()
-        self.assertEqual(task.key_buffer(1), b"raisefoobar")
+        # task buffers are reset at thread termination, check captured msg
+        self.assertEqual(eh.msg, b"raisefoobar")
         time.sleep(1) # for pretty display, because unhandled exception
                       # traceback may be sent to stderr after the join()
         self.assertFalse(task.running())


### PR DESCRIPTION
Fixes a flaky test seen on master (Python 3.14 job, `AssertionError: b'' != b'raisefoobar'`): https://github.com/clustershell/clustershell/actions/runs/29529565499/job/87726353955

- after an unhandled exception in a Task thread, `_thread_start()` runs `excepthook` then `_terminate(kill=True)`, which resets task buffers
- `join()` returns as soon as `_resume()`'s `finally` block notifies, so reading `task.key_buffer()` afterwards races with that reset; the test usually won only because the default excepthook's stderr traceback slows the task thread down (reproduced deterministically by silencing excepthook)
- check the message captured by the event handler instead, which still verifies the line was delivered to `ev_read()` before the exception was raised
