### PR TITLE
Tree: support optional route weights in topology.conf (#374)

### DIFF
--- a/conf/topology.conf.example
+++ b/conf/topology.conf.example
@@ -10,3 +10,11 @@
 rio0: rio[10-13]
 rio[10-11]: rio[100-240]
 rio[12-13]: rio[300-440]
+
+# Optional relative weights for gateway nodes (default weight: 1).
+# A gateway with weight 2 is selected for twice as many target nodes as a
+# gateway with weight 1. A weight of 0 defines a standby gateway, only used
+# when no other gateway is available for a route.
+#[weights]
+#rio10: 2
+#rio13: 0

--- a/doc/sphinx/config.rst
+++ b/doc/sphinx/config.rst
@@ -842,12 +842,18 @@ the other ClusterShell configuration files, the system-wide default being::
 
 .. highlight:: ini
 
-Routes are declared under a ``[routes]`` section, for example::
+Routes are declared under a ``[routes]`` section, and an optional
+``[weights]`` section may define relative route weights for gateway nodes
+(weight 0 defines a standby gateway), for example::
 
     [routes]
     rio0: rio[10-13]
     rio[10-11]: rio[100-240]
     rio[12-13]: rio[300-440]
+
+    [weights]
+    rio10: 2
+    rio13: 0
 
 .. highlight:: text
 

--- a/doc/sphinx/tools/clush.rst
+++ b/doc/sphinx/tools/clush.rst
@@ -220,6 +220,31 @@ The example above defines the following topology graph::
 **topology.conf**, but any route definition with an empty node set
 is ignored (a message is printed in debug mode in that case).
 
+.. highlight:: ini
+
+Since version 1.11, an optional ``[weights]`` section may define relative
+route weights for gateway nodes (the default weight is 1). When several
+gateways are available for a route, each target node is dispatched to the
+gateway with the least number of current connections relative to its
+weight: a gateway with weight 2 is selected for about twice as many target
+nodes as a gateway with weight 1. A weight of 0 defines a standby gateway,
+only used when no other gateway is available for the route::
+
+  [weights]
+  rio10: 2
+  rio13: 0
+
+.. highlight:: text
+
+In the example above, ``rio10`` handles about twice as many target nodes as
+``rio11``, and ``rio13`` is only used if ``rio12`` becomes unreachable.
+Weights may be defined using any valid node set (including node groups), in
+which case the weight applies to each node of the set individually.
+Entries are applied in file order: when node sets overlap, the last entry
+wins for the nodes in common (repeating the exact same key is an error).
+Entries that do not match any gateway node are ignored, with a warning
+when a weight entry has no effect at all.
+
 At runtime, ClusterShell will pick an initial propagation tree from this
 topology graph definition and the current root node. Multiple admin/root
 nodes may be defined in the file.

--- a/lib/ClusterShell/Propagation.py
+++ b/lib/ClusterShell/Propagation.py
@@ -58,6 +58,8 @@ class PropagationTreeRouter(object):
         self.fanout = fanout
         self.nodes_fanin = {}
         self.table = None
+        # route weights (getattr: tree may come from an older version)
+        self.weights = getattr(topology, 'weights', None) or {}
 
         self.table_generate(root, topology)
         self._unreachable_hosts = NodeSet()
@@ -113,7 +115,7 @@ class PropagationTreeRouter(object):
     def next_hop(self, dst):
         """perform the next hop resolution. If several hops are
         available, then, the one with the least number of current jobs
-        will be returned
+        relative to its route weight will be returned
         """
         if dst in self._unreachable_hosts:
             raise RouteResolvingError(
@@ -160,9 +162,11 @@ class PropagationTreeRouter(object):
         self._unreachable_hosts.add(dst)
 
     def _best_next_hop(self, candidates):
-        """find out a good next hop gateway"""
+        """find out a good next hop gateway according to route weights"""
         backup = None
         backup_connections = 1e400 # infinity
+        standby = None
+        standby_connections = 1e400
 
         candidates = candidates.difference(self._unreachable_hosts)
 
@@ -174,10 +178,23 @@ class PropagationTreeRouter(object):
             #if connections < self.fanout:
             #    # currently, the first one is the best
             #    return host
+            weight = self.weights.get(host, 1)
+            if weight == 0:
+                # zero weight: standby gateway, used as a last resort only
+                if standby_connections > connections:
+                    standby = host
+                    standby_connections = connections
+                continue
+
+            # weighted least-connections (Python 2: force true division)
+            connections /= float(weight)
             if backup_connections > connections:
                 backup = host
                 backup_connections = connections
-        return backup
+
+        if backup is not None:
+            return backup
+        return standby
 
 
 class PropagationChannel(Channel):

--- a/lib/ClusterShell/Topology.py
+++ b/lib/ClusterShell/Topology.py
@@ -28,12 +28,15 @@ according to the configuration file.
 
 This file must be written using the following syntax:
 
-# for now only [routes] tree is taken in account:
 [routes]
 admin: first_level_gateways[0-10]
 first_level_gateways[0-10]: second_level_gateways[0-100]
 second_level_gateways[0-100]: nodes[0-2000]
 ...
+
+# optional relative weights for gateway nodes (default: 1, 0 = standby)
+[weights]
+second_level_gateways[0-50]: 2
 """
 
 try:
@@ -193,6 +196,8 @@ class TopologyTree(object):
         """initialize a new TopologyTree instance."""
         self.root = None
         self.groups = []
+        # optional route weights for gateway nodes ([weights] section)
+        self.weights = {}
 
     def load(self, rootnode):
         """load topology tree"""
@@ -434,6 +439,7 @@ class TopologyParser(configparser.ConfigParser):
         self.optionxform = str  # case sensitive parser
 
         self._topology = {}
+        self._weights = {}
         self.graph = None
         self._tree = None
 
@@ -453,10 +459,14 @@ class TopologyParser(configparser.ConfigParser):
                 warnings.warn("topology: [Main] section is deprecated since "
                               "v1.7, use [routes] instead", DeprecationWarning)
                 self._topology = self.items("Main")
+            weights_conf = []
+            if self.has_section("weights"):
+                weights_conf = self.items("weights")
         except configparser.Error:
             raise TopologyError(
                 'Invalid configuration file: %s' % filename)
         self._build_graph()
+        self._build_weights(weights_conf)
 
     def _build_graph(self):
         """build a network topology graph according to the information we got
@@ -476,6 +486,39 @@ class TopologyParser(configparser.ConfigParser):
             if src_ns and dst_ns:
                 self.graph.add_route(src_ns, dst_ns)
 
+    def _build_weights(self, weights_conf):
+        """build the route weights map from the [weights] config section"""
+        # new dict on each load; trees built before keep their own weights
+        self._weights = {}
+        for nodes, weightstr in weights_conf:
+            # like routes, weight node sets may use NodeSet groups and any
+            # empty sets are ignored
+            node_ns = NodeSet(nodes)
+            if not node_ns:
+                LOGGER.debug('Failed to resolve weight node set: %s', nodes)
+                continue
+            try:
+                weight = int(weightstr)
+                if weight < 0:
+                    raise ValueError()
+            except ValueError:
+                raise TopologyError('Invalid weight "%s" for %s'
+                                    % (weightstr, node_ns))
+
+            # only router nodes may be used as next hops
+            other_ns = node_ns - self.graph._routing.aggregated_src
+            if other_ns:
+                node_ns.difference_update(other_ns)
+                if node_ns:
+                    LOGGER.debug('Ignoring weight for non-router node set: %s',
+                                 other_ns)
+                else:
+                    # raise exposure of a weight entry with no effect at all
+                    LOGGER.warning('Ignoring weight for non-router node set: '
+                                   '%s', other_ns)
+            for node in node_ns:
+                self._weights[node] = weight
+
     def tree(self, root, force_rebuild=False):
         """Return a previously generated propagation tree or build it if
         required. As rebuilding tree can be quite expensive, once built,
@@ -484,4 +527,5 @@ class TopologyParser(configparser.ConfigParser):
         """
         if self._tree is None or force_rebuild:
             self._tree = self.graph.to_tree(root)
+            self._tree.weights = self._weights
         return self._tree

--- a/tests/TreeRouterTest.py
+++ b/tests/TreeRouterTest.py
@@ -1,0 +1,139 @@
+# ClusterShell propagation tree router test suite
+
+"""Unit test for ClusterShell PropagationTreeRouter"""
+
+import unittest
+from tempfile import NamedTemporaryFile
+
+from ClusterShell.NodeSet import NodeSet
+from ClusterShell.Propagation import PropagationTreeRouter, RouteResolvingError
+from ClusterShell.Topology import TopologyParser
+
+
+class TreeRouterTest(unittest.TestCase):
+    """test PropagationTreeRouter gateway selection and route weights"""
+
+    def _tree(self, topoconf, root='admin'):
+        """helper to build a topology tree from a config string"""
+        with NamedTemporaryFile() as tmpfile:
+            tmpfile.write(topoconf)
+            tmpfile.flush()
+            parser = TopologyParser(tmpfile.name)
+            return parser.tree(root)
+
+    def _router(self, topoconf, root='admin'):
+        """helper to build a PropagationTreeRouter from a config string"""
+        return PropagationTreeRouter(root, self._tree(topoconf, root))
+
+    def _distribution(self, router, targets):
+        """helper to get the target distribution per gateway"""
+        dist = {}
+        for gateway, dstset in router.dispatch(NodeSet(targets)):
+            dist.setdefault(str(gateway), NodeSet()).add(dstset)
+        return dist
+
+    def testDispatchBalanced(self):
+        """test dispatch without weights (balanced)"""
+        router = self._router(b'[routes]\n'
+                              b'admin: gw[1-2]\n'
+                              b'gw[1-2]: nodes[0-11]\n')
+        dist = self._distribution(router, 'nodes[0-11]')
+        self.assertEqual(sorted(dist), ['gw1', 'gw2'])
+        self.assertEqual(len(dist['gw1']), 6)
+        self.assertEqual(len(dist['gw2']), 6)
+
+    def testDispatchWeighted(self):
+        """test dispatch with weights"""
+        router = self._router(b'[routes]\n'
+                              b'admin: gw[1-2]\n'
+                              b'gw[1-2]: nodes[0-11]\n'
+                              b'[weights]\n'
+                              b'gw1: 2\n')
+        dist = self._distribution(router, 'nodes[0-11]')
+        self.assertEqual(sorted(dist), ['gw1', 'gw2'])
+        self.assertEqual(len(dist['gw1']), 8)
+        self.assertEqual(len(dist['gw2']), 4)
+
+    def testDispatchStandby(self):
+        """test dispatch with zero-weight standby gateway"""
+        router = self._router(b'[routes]\n'
+                              b'admin: gw[1-2],gwb\n'
+                              b'gw[1-2],gwb: nodes[0-11]\n'
+                              b'[weights]\n'
+                              b'gwb: 0\n')
+        dist = self._distribution(router, 'nodes[0-11]')
+        self.assertEqual(sorted(dist), ['gw1', 'gw2'])
+        self.assertEqual(len(dist['gw1']), 6)
+        self.assertEqual(len(dist['gw2']), 6)
+
+    def testDispatchStandbyFailover(self):
+        """test dispatch failover to standby gateway"""
+        router = self._router(b'[routes]\n'
+                              b'admin: gw[1-2],gwb\n'
+                              b'gw[1-2],gwb: nodes[0-11]\n'
+                              b'[weights]\n'
+                              b'gwb: 0\n')
+        router.mark_unreachable('gw1')
+        router.mark_unreachable('gw2')
+        dist = self._distribution(router, 'nodes[0-11]')
+        self.assertEqual(sorted(dist), ['gwb'])
+        self.assertEqual(len(dist['gwb']), 12)
+
+    def testDispatchAllStandby(self):
+        """test dispatch with only zero-weight gateways (balanced)"""
+        router = self._router(b'[routes]\n'
+                              b'admin: gw[1-2]\n'
+                              b'gw[1-2]: nodes[0-11]\n'
+                              b'[weights]\n'
+                              b'gw[1-2]: 0\n')
+        dist = self._distribution(router, 'nodes[0-11]')
+        self.assertEqual(sorted(dist), ['gw1', 'gw2'])
+        self.assertEqual(len(dist['gw1']), 6)
+        self.assertEqual(len(dist['gw2']), 6)
+
+    def testDispatchWeightsDeeperLevel(self):
+        """test route weights used from a gateway node"""
+        tree = self._tree(b'[routes]\n'
+                          b'admin: gwa[1-2]\n'
+                          b'gwa[1-2]: gwb[1-2]\n'
+                          b'gwb[1-2]: nodes[0-11]\n'
+                          b'[weights]\n'
+                          b'gwb1: 2\n')
+        # a gateway builds its own router from the propagated tree
+        router = PropagationTreeRouter('gwa1', tree)
+        dist = self._distribution(router, 'nodes[0-11]')
+        self.assertEqual(sorted(dist), ['gwb1', 'gwb2'])
+        self.assertEqual(len(dist['gwb1']), 8)
+        self.assertEqual(len(dist['gwb2']), 4)
+
+    def testAllUnreachable(self):
+        """test resolution error with all gateways unreachable"""
+        router = self._router(b'[routes]\n'
+                              b'admin: gw[1-2],gwb\n'
+                              b'gw[1-2],gwb: nodes[0-11]\n'
+                              b'[weights]\n'
+                              b'gwb: 0\n')
+        router.mark_unreachable('gw1')
+        router.mark_unreachable('gw2')
+        router.mark_unreachable('gwb')
+        self.assertRaises(RouteResolvingError, router.next_hop,
+                          NodeSet('nodes5'))
+        self.assertRaises(RouteResolvingError, list,
+                          router.dispatch(NodeSet('nodes[0-11]')))
+
+    def testTopologyWithoutWeightsAttr(self):
+        """test router with a topology tree lacking weights (pre-1.11)"""
+        tree = self._tree(b'[routes]\n'
+                          b'admin: gw[1-2]\n'
+                          b'gw[1-2]: nodes[0-11]\n')
+        # simulate a tree unpickled from an older ClusterShell version
+        del tree.weights
+        router = PropagationTreeRouter('admin', tree)
+        self.assertEqual(router.weights, {})
+        dist = self._distribution(router, 'nodes[0-11]')
+        self.assertEqual(len(dist['gw1']), 6)
+        self.assertEqual(len(dist['gw2']), 6)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/TreeTopologyTest.py
+++ b/tests/TreeTopologyTest.py
@@ -3,6 +3,7 @@
 
 """Unit test for Topology"""
 
+import pickle
 import unittest
 import warnings
 from tempfile import NamedTemporaryFile
@@ -13,6 +14,7 @@ from textwrap import dedent
 #from guppy import hpy
 # ---
 
+from ClusterShell.Communication import GW_PICKLE_PROTOCOL
 from ClusterShell.Topology import *
 from ClusterShell.NodeSet import NodeSet, set_std_group_resolver
 from ClusterShell.NodeSet import set_std_group_resolver_config
@@ -368,6 +370,134 @@ class TopologyTest(unittest.TestCase):
             parser = TopologyParser()
             self.assertRaises(TopologyError, parser.load, tmpfile.name)
 
+    def testConfigurationParserWeights(self):
+        """test weights section parsing"""
+        with NamedTemporaryFile() as tmpfile:
+            tmpfile.write(b'[routes]\n')
+            tmpfile.write(b'admin: gw[1-2],gwb\n')
+            tmpfile.write(b'gw[1-2],gwb: nodes[0-9]\n')
+            tmpfile.write(b'[weights]\n')
+            tmpfile.write(b'gw1: 2\n')
+            tmpfile.write(b'gwb: 0\n')
+            tmpfile.flush()
+            parser = TopologyParser(tmpfile.name)
+            tree = parser.tree('admin')
+            self.assertEqual(tree.weights, {'gw1': 2, 'gwb': 0})
+
+    def testConfigurationParserNoWeights(self):
+        """test missing weights section"""
+        with NamedTemporaryFile() as tmpfile:
+            tmpfile.write(b'[routes]\n')
+            tmpfile.write(b'admin: gw[1-2]\n')
+            tmpfile.write(b'gw[1-2]: nodes[0-9]\n')
+            tmpfile.flush()
+            parser = TopologyParser(tmpfile.name)
+            tree = parser.tree('admin')
+            self.assertEqual(tree.weights, {})
+
+    def testConfigurationParserWeightsInvalid(self):
+        """test invalid weights"""
+        for weightline in (b'gw1: two\n', b'gw1: -1\n', b'gw1: 1.5\n'):
+            with NamedTemporaryFile() as tmpfile:
+                tmpfile.write(b'[routes]\n')
+                tmpfile.write(b'admin: gw[1-2]\n')
+                tmpfile.write(b'gw[1-2]: nodes[0-9]\n')
+                tmpfile.write(b'[weights]\n')
+                tmpfile.write(weightline)
+                tmpfile.flush()
+                parser = TopologyParser()
+                self.assertRaises(TopologyError, parser.load, tmpfile.name)
+
+    def testConfigurationParserWeightsNonRouter(self):
+        """test weights for non-router nodes are ignored"""
+        with NamedTemporaryFile() as tmpfile:
+            tmpfile.write(b'[routes]\n')
+            tmpfile.write(b'admin: gw[1-2]\n')
+            tmpfile.write(b'gw[1-2]: nodes[0-9]\n')
+            tmpfile.write(b'[weights]\n')
+            # gw3 is not part of any route
+            tmpfile.write(b'gw[2-3]: 4\n')
+            # leaf nodes cannot be next hops
+            tmpfile.write(b'nodes[0-9]: 2\n')
+            tmpfile.flush()
+            parser = TopologyParser()
+            # a weight entry with no effect at all generates a warning
+            with self.assertLogs('ClusterShell.Topology',
+                                 level='WARNING') as cm:
+                parser.load(tmpfile.name)
+            self.assertEqual(len(cm.records), 1)
+            self.assertIn('nodes[0-9]', cm.output[0])
+            tree = parser.tree('admin')
+            self.assertEqual(tree.weights, {'gw2': 4})
+
+    def testConfigurationParserWeightsDuplicateKey(self):
+        """test duplicate weight keys are rejected (strict ini parsing)"""
+        with NamedTemporaryFile() as tmpfile:
+            tmpfile.write(b'[routes]\n')
+            tmpfile.write(b'admin: gw[1-2]\n')
+            tmpfile.write(b'gw[1-2]: nodes[0-9]\n')
+            tmpfile.write(b'[weights]\n')
+            tmpfile.write(b'gw1: 2\n')
+            tmpfile.write(b'gw1: 0\n')
+            tmpfile.flush()
+            parser = TopologyParser()
+            self.assertRaises(TopologyError, parser.load, tmpfile.name)
+
+    def testConfigurationParserWeightsOverlap(self):
+        """test overlapping weights (last wins)"""
+        with NamedTemporaryFile() as tmpfile:
+            tmpfile.write(b'[routes]\n')
+            tmpfile.write(b'admin: gw[1-4]\n')
+            tmpfile.write(b'gw[1-4]: nodes[0-9]\n')
+            tmpfile.write(b'[weights]\n')
+            tmpfile.write(b'gw[1-4]: 2\n')
+            tmpfile.write(b'gw4: 0\n')
+            tmpfile.flush()
+            parser = TopologyParser(tmpfile.name)
+            tree = parser.tree('admin')
+            self.assertEqual(tree.weights,
+                             {'gw1': 2, 'gw2': 2, 'gw3': 2, 'gw4': 0})
+
+    def testConfigurationParserWeightsReload(self):
+        """test previously built tree keeps its weights after reload"""
+        parser = TopologyParser()
+        with NamedTemporaryFile() as tmpfile:
+            tmpfile.write(b'[routes]\n')
+            tmpfile.write(b'admin: gw[1-2]\n')
+            tmpfile.write(b'gw[1-2]: nodes[0-9]\n')
+            tmpfile.write(b'[weights]\n')
+            tmpfile.write(b'gw1: 2\n')
+            tmpfile.flush()
+            parser.load(tmpfile.name)
+            tree1 = parser.tree('admin')
+            self.assertEqual(tree1.weights, {'gw1': 2})
+        with NamedTemporaryFile() as tmpfile:
+            tmpfile.write(b'[routes]\n')
+            tmpfile.write(b'admin: gw[1-2]\n')
+            tmpfile.write(b'gw[1-2]: nodes[0-9]\n')
+            tmpfile.write(b'[weights]\n')
+            tmpfile.write(b'gw1: 5\n')
+            tmpfile.flush()
+            parser.load(tmpfile.name)
+            tree2 = parser.tree('admin', force_rebuild=True)
+            self.assertEqual(tree2.weights, {'gw1': 5})
+            # tree1 keeps the weights it was built with
+            self.assertEqual(tree1.weights, {'gw1': 2})
+
+    def testConfigurationParserWeightsPickle(self):
+        """test weights across pickling (gateway transport)"""
+        with NamedTemporaryFile() as tmpfile:
+            tmpfile.write(b'[routes]\n')
+            tmpfile.write(b'admin: gw[1-2]\n')
+            tmpfile.write(b'gw[1-2]: nodes[0-9]\n')
+            tmpfile.write(b'[weights]\n')
+            tmpfile.write(b'gw2: 3\n')
+            tmpfile.flush()
+            parser = TopologyParser(tmpfile.name)
+            tree = parser.tree('admin')
+            tree2 = pickle.loads(pickle.dumps(tree, GW_PICKLE_PROTOCOL))
+            self.assertEqual(tree2.weights, {'gw2': 3})
+
     def testPrintingTree(self):
         """test printing tree"""
         with NamedTemporaryFile() as tmpfile:
@@ -561,3 +691,32 @@ class TopologyWithGroupsTest(unittest.TestCase):
             tmpfile.flush()
             parser = TopologyParser()
             self.assertRaises(TopologyError, parser.load, tmpfile.name)
+
+    def testGroupsWeights(self):
+        """test topology weights with node groups"""
+        with NamedTemporaryFile() as tmpfile:
+            tmpfile.write(b'[routes]\n')
+            tmpfile.write(b'Controller-vm1:Controller-vm30\n')
+            tmpfile.write(b'Controller-vm30:Computer101\n')
+            tmpfile.write(b'[weights]\n')
+            tmpfile.write(b'@gw: 2\n')
+            tmpfile.flush()
+            parser = TopologyParser()
+            parser.load(tmpfile.name)
+            tree = parser.tree('Controller-vm1')
+            self.assertEqual(tree.weights,
+                             {'Controller-vm1': 2, 'Controller-vm30': 2})
+
+    def testGroupsWeightsUnresolved(self):
+        """test topology weights with unresolved node set"""
+        with NamedTemporaryFile() as tmpfile:
+            tmpfile.write(b'[routes]\n')
+            tmpfile.write(b'Controller-vm1:Controller-vm30\n')
+            tmpfile.write(b'Controller-vm30:Computer101\n')
+            tmpfile.write(b'[weights]\n')
+            tmpfile.write(b'Un*resolved3: 2\n')
+            tmpfile.flush()
+            parser = TopologyParser()
+            parser.load(tmpfile.name)
+            tree = parser.tree('Controller-vm1')
+            self.assertEqual(tree.weights, {})


### PR DESCRIPTION
Implement route weights for tree mode, as suggested in #374.

An optional `[weights]` section in `topology.conf` defines relative route weights for gateway nodes (default weight: 1):

```ini
[weights]
gw1: 3
gw2: 2
gwspare: 0
```

- Each target node is dispatched to the gateway with the least number of current connections relative to its weight, so a gateway with weight 3 handles about 3x more targets than a gateway with weight 1. No behavior change when `[weights]` is absent.
- A weight of 0 defines a standby gateway, only used when no other gateway is available for the route, e.g. after all regular gateways were marked unreachable.
- Example: with the weights above and 4 gateways serving `node[001-120]`, dispatch yields 60/40/20/0 targets; once `gw[1-3]` are marked unreachable, `gwspare` takes all 120.
- Weight entries use regular node set syntax (including node groups) and apply to each node of the set individually. Entries are applied in file order (last one wins on overlapping node sets); an entry that does not match any router node is ignored, with a warning when it has no effect at all.
- Weights are carried by the propagated topology tree, so gateways apply them at deeper levels of the tree; topology trees from older versions (without weights) still work.
- Older ClusterShell versions ignore the new section, so a `topology.conf` using `[weights]` stays compatible with them.
- Add `PropagationTreeRouter` unit tests (new `tests/TreeRouterTest.py`), parser tests, and documentation (config.rst, clush.rst tree mode section, topology.conf.example).

Closes #374
