### PR TITLE
Tree: close temporary tar files used by copy and rcopy

### DIFF
--- a/lib/ClusterShell/Worker/Tree.py
+++ b/lib/ClusterShell/Worker/Tree.py
@@ -335,18 +335,18 @@ class TreeWorker(DistantWorker):
         if self.source and not self.reverse:
             try:
                 # create temporary tar file with all source files
-                tmptar = tempfile.TemporaryFile()
-                tar = tarfile.open(fileobj=tmptar, mode='w:')
-                tar.add(self.source, arcname=arcname)
-                tar.close()
-                tmptar.flush()
-                # read generated tar file
-                tmptar.seek(0)
-                rbuf = tmptar.read(32768)
-                # send tar data to remote targets only
-                while len(rbuf) > 0:
-                    self._write_remote(rbuf)
+                with tempfile.TemporaryFile() as tmptar:
+                    tar = tarfile.open(fileobj=tmptar, mode='w:')
+                    tar.add(self.source, arcname=arcname)
+                    tar.close()
+                    tmptar.flush()
+                    # read generated tar file
+                    tmptar.seek(0)
                     rbuf = tmptar.read(32768)
+                    # send tar data to remote targets only
+                    while len(rbuf) > 0:
+                        self._write_remote(rbuf)
+                        rbuf = tmptar.read(32768)
             except OSError as exc:
                 raise WorkerError(exc)
 
@@ -435,6 +435,12 @@ class TreeWorker(DistantWorker):
             DistantWorker._on_node_msgline(self, node, msg, sname)
             return
 
+        # drop late data after node terminal event (eg. gateway timeout flush)
+        if node not in self.gwtargets.get(str(gateway), ()):
+            self.logger.debug("dropping late %d bytes from %s via gw %s",
+                              len(msg), node, gateway)
+            return
+
         # rcopy only: we expect base64 encoded tar content on stdout
         encoded = self._rcopy_bufs.setdefault(node, b'') + msg
         if node not in self._rcopy_tars:
@@ -481,6 +487,8 @@ class TreeWorker(DistantWorker):
                 finally:
                     if tmptar is not None:
                         tmptar.close()
+                    # TarFile does not close a caller-provided fileobj
+                    tarfileobj.close()
                 del self._rcopy_bufs[node]
                 del self._rcopy_tars[node]
             else:
@@ -496,6 +504,13 @@ class TreeWorker(DistantWorker):
         self._close_count += 1
         self._has_timeout = True
         self.gwtargets[str(gateway)].remove(node)
+
+        # discard rcopy data: the tar file of a timed-out node is incomplete
+        if self.source and self.reverse and node in self._rcopy_bufs:
+            self._rcopy_tars[node].close()
+            del self._rcopy_bufs[node]
+            del self._rcopy_tars[node]
+
         self._check_fini(gateway)
 
     def _on_node_close(self, node, rc):
@@ -559,6 +574,12 @@ class TreeWorker(DistantWorker):
         self.logger.debug("check_fini %s %s", self._close_count,
                           self._target_count)
         if self._close_count >= self._target_count:
+            # safety net: close any leftover rcopy temporary tar file
+            for tarfileobj in self._rcopy_tars.values():
+                tarfileobj.close()
+            self._rcopy_tars.clear()
+            self._rcopy_bufs.clear()
+
             handler = self.eh
             if handler:
                 # also use hasattr check because ev_timeout was missing in 1.8.0

--- a/tests/TreeWorkerTest.py
+++ b/tests/TreeWorkerTest.py
@@ -14,9 +14,11 @@ The hostname mock command available in tests/bin needs to be
 used on the remote nodes (tests/bin added to PATH in .bashrc).
 """
 
+import gc
 import logging
 import os
 from os.path import basename, join
+import tempfile
 import unittest
 import warnings
 
@@ -594,6 +596,18 @@ class TreeWorkerTest(TreeWorkerTestBase):
         """test tree copy: file, gateway is target"""
         self._tree_copy_file(NODE_GATEWAY)
 
+    def test_tree_copy_no_unclosed_file_warning(self):
+        """test tree copy: temporary tar file is closed (no fd leak)"""
+        gc.collect()  # drain pre-existing garbage before the watch window
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            self._tree_copy_file(NODE_DISTANT)
+            task_terminate()
+            gc.collect()
+        self.assertEqual([str(x.message) for x in w
+                          if issubclass(x.category, ResourceWarning)
+                          and 'unclosed file' in str(x.message)], [])
+
     def test_tree_copy_file_error_direct(self):
         """test tree copy: bad dest, direct target -> stderr (#622)"""
         self._tree_copy_file_error(NODE_DIRECT)
@@ -684,6 +698,77 @@ class TreeWorkerTest(TreeWorkerTestBase):
             warnings.simplefilter('always')
             self._tree_rcopy_file(NODE_DISTANT)
         self.assertEqual([x for x in w if 'tarfile' in x.filename], [])
+
+    def test_tree_rcopy_no_unclosed_file_warning(self):
+        """test tree rcopy: temporary tar files are closed (no fd leak)"""
+        gc.collect()  # drain pre-existing garbage before the watch window
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            self._tree_rcopy_file(NODE_DISTANT)
+            task_terminate()
+            gc.collect()
+        self.assertEqual([str(x.message) for x in w
+                          if issubclass(x.category, ResourceWarning)
+                          and 'unclosed file' in str(x.message)], [])
+
+    def test_tree_rcopy_timeout_closes_node_tar(self):
+        """test tree rcopy: temporary tar file closed at node timeout"""
+        teh = TEventHandler()
+        worker = TreeWorker(NODE_DISTANT2, teh, 10, source='/dummy-src',
+                            dest='/dummy-dest', reverse=True)
+        worker.task = self.task
+        try:
+            # a timed-out rcopy node leaves an incomplete tar file behind
+            tmpf = tempfile.TemporaryFile()
+            worker._rcopy_bufs[NODE_DISTANT] = b''
+            worker._rcopy_tars[NODE_DISTANT] = tmpf
+            # second target still active: worker completion is not reached
+            worker.gwtargets[NODE_GATEWAY] = set(NodeSet(NODE_DISTANT2))
+            worker._target_count = 2
+            worker._on_remote_node_timeout(NODE_DISTANT, NODE_GATEWAY)
+            self.assertTrue(tmpf.closed)
+            self.assertEqual(worker._rcopy_tars, {})
+            self.assertEqual(worker._rcopy_bufs, {})
+            self.assertEqual(teh.ev_close_cnt, 0)
+        finally:
+            # close the never-scheduled worker's internal port pipe
+            worker._port.streams.clear()
+
+    def test_tree_rcopy_timeout_closes_leftover_tars(self):
+        """test tree rcopy: leftover temporary tar files closed at completion"""
+        teh = TEventHandler()
+        worker = TreeWorker(NODE_DISTANT, teh, 10, source='/dummy-src',
+                            dest='/dummy-dest', reverse=True)
+        try:
+            # a timed-out rcopy node leaves its temporary tar file behind
+            tmpf = tempfile.TemporaryFile()
+            worker._rcopy_tars[NODE_DISTANT] = tmpf
+            worker._target_count = 1
+            worker._close_count = 1
+            worker._has_timeout = True
+            worker._check_fini()
+            self.assertTrue(tmpf.closed)
+            self.assertEqual(worker._rcopy_tars, {})
+            self.assertEqual(teh.ev_timedout_cnt, 1)
+            self.assertEqual(teh.ev_close_cnt, 1)
+        finally:
+            # close the never-scheduled worker's internal port pipe
+            worker._port.streams.clear()
+
+    def test_tree_rcopy_late_msgline_dropped(self):
+        """test tree rcopy: data received after node terminal event is dropped"""
+        teh = TEventHandler()
+        worker = TreeWorker(NODE_DISTANT, teh, 10, source='/dummy-src',
+                            dest='/dummy-dest', reverse=True)
+        try:
+            # gateway grooming flush may follow its TimeoutMessage
+            worker._on_remote_node_msgline(NODE_DISTANT, b'QUJDRA==', 'stdout',
+                                           'gateway-node')
+            self.assertEqual(worker._rcopy_tars, {})
+            self.assertEqual(worker._rcopy_bufs, {})
+        finally:
+            # close the never-scheduled worker's internal port pipe
+            worker._port.streams.clear()
 
     def test_tree_rcopy_preserves_mode(self):
         """test tree rcopy: preserves file mode bits (PEP 706 regression)"""


### PR DESCRIPTION
TreeWorker never closes its temporary tar files: one per forward copy `_launch()`, one per rcopy source node. Their file descriptors stay open until the file objects are garbage-collected, which is deferred by reference cycles — and for a timed-out rcopy node cannot happen before the worker object itself is released. This means `ResourceWarning: unclosed file` noise in warning-enabled runs and open-fd accumulation in long-running processes embedding the library. Found while writing the tree copy tests for #680.

- copy: wrap the temporary tar file in a `with` block in `_launch()`
- rcopy: close the per-node temporary tar file in `_on_remote_node_close()` — `TarFile.close()` [does not close](https://docs.python.org/3/library/tarfile.html#tarfile.TarFile) a caller-provided `fileobj`
- rcopy: close the temporary tar file of a timed-out node in `_on_remote_node_timeout()`, where its content is known to be incomplete
- rcopy: as a safety net, close any leftover tar file at worker completion in `_check_fini()`, and drop stdout received for a node that is no longer an active target of its gateway (the gateway's final grooming flush follows its `TimeoutMessage`)
- add regression tests for these paths (fail before the fix, pass after)
