### PR TITLE
RangeSetND: fix exponential splitting in difference_update()

### DIFF
--- a/lib/ClusterShell/RangeSet.py
+++ b/lib/ClusterShell/RangeSet.py
@@ -1463,16 +1463,22 @@ class RangeSetND(object):
                 while len(procvx1) > 0: # refine diff for each resulting vector
                     rgproc1 = procvx1.pop(0)
                     tmpvx = []
+                    # carved axes are narrowed to the intersection so that
+                    # generated vectors are pairwise disjoint
+                    carve = list(rgproc1)
                     for pos, (rg1, rg2) in enumerate(zip(rgproc1, rgvec2)):
-                        if rg1 == rg2 or rg1 < rg2: # issubset
+                        if rg1.issubset(rg2):
                             pass
-                        elif rg1 & rg2:             # intersect
-                            tmpvec = list(rgproc1)
-                            tmpvec[pos] = rg1.difference(rg2)
-                            tmpvx.append(tmpvec)
-                        else:                       # disjoint
-                            tmpvx = [ rgproc1 ]     # reset previous work
-                            break
+                        else:
+                            inter = rg1 & rg2
+                            if inter:               # intersect
+                                tmpvec = list(carve)
+                                tmpvec[pos] = rg1.difference(rg2)
+                                tmpvx.append(tmpvec)
+                                carve[pos] = inter
+                            else:                   # disjoint
+                                tmpvx = [ rgproc1 ] # reset previous work
+                                break
                     if tmpvx:
                         nextvx1 += tmpvx
                 if nextvx1:

--- a/tests/RangeSetNDTest.py
+++ b/tests/RangeSetNDTest.py
@@ -311,6 +311,19 @@ class RangeSetNDTest(unittest.TestCase):
         rn2 = RangeSetND([["10", "10"], ["9", "12-15"], ["10-12", "11-15"], ["11", "14"]])
         self.assertRaises(KeyError, rn1.difference_update, rn2, strict=True)
 
+        # subtracting scattered elements from a box must generate a linear
+        # number of disjoint vectors, not an exponential overlapping split
+        rn1 = RangeSetND([["0-9", "0-9", "0-9"]])
+        pts = [(0, 0, 0), (1, 2, 3), (2, 4, 6), (3, 7, 0), (4, 5, 6),
+               (7, 8, 9), (8, 1, 5), (9, 9, 9)]
+        rn2 = RangeSetND(pts)
+        rn1.difference_update(rn2)
+        self.assertTrue(len(rn1._veclist) <= 2 * len(pts) + 1)
+        self.assertEqual(len(rn1), 1000 - len(pts))
+        for pt in pts:
+            self.assertFalse(RangeSetND([pt]).issubset(rn1))
+        self.assertTrue(RangeSetND([(5, 5, 5)]).issubset(rn1))
+
         if sys.version_info >= (2, 5, 0):
             rn1 = RangeSetND([["10", "10-13"], ["10", "9-12"]])
             rn2 = RangeSetND([["10", "10"]])


### PR DESCRIPTION
Removing a few scattered nodes from a large multi-dimensional node set could make ClusterShell hang and eat memory: subtracting just 8 nodes from a folded 100x100x100 RangeSetND never finished, and around 100 nodes it peaked over 800 MB.

The cause is in how `difference_update()` splits vectors. Each subtraction can split a vector into up to dim() pieces, and those pieces overlapped each other — so every subtracted vector could re-split all the pieces of the previous one, multiplying the work at each step. For the mathematicians in the room: the box difference V \ W was decomposed as the union over axes i of V1 x ... x (Vi \ Wi) x ... x Vd, which is correct but not disjoint; narrowing the already-processed axes to their intersection Vi∩Wi makes the pieces pairwise disjoint. A subtracted vector now only touches the few pieces it actually overlaps, and the piece count grows linearly instead of exponentially.

Results: the 8-node case above drops to ~1 ms. Subtracting 5 scattered nodes (the largest case that finished before the fix) goes from 2.1 s to 0.16 s including re-folding, and a 256-node rack minus 3 nodes is 2.4x faster. Cases that were already fast are unchanged.

This also fixes or speeds up everything built on `difference_update()`: `NodeSet` difference (`-x`/`-X` on multi-dimensional node sets), `issuperset()`, `issubset()`, `==`, `in`, and strict removal.

Results are unchanged node-for-node: verified with a 15,000-case differential fuzz against a pure-Python oracle, the full test suites, and a py2.7/EL7 run. One cosmetic note: sets using autostep that lost their step notation after `copy()` + difference (a pre-existing container-autostep quirk) can now keep it, since the disjoint vectors more often take the folding path that preserves axis autostep.
