### PR TITLE
Worker: speed up event handler signature checks

### DIFF
--- a/lib/ClusterShell/Worker/Worker.py
+++ b/lib/ClusterShell/Worker/Worker.py
@@ -36,6 +36,17 @@ from ClusterShell.NodeSet import NodeSet
 from ClusterShell.Engine.Engine import FANOUT_UNLIMITED, FANOUT_DEFAULT
 
 
+def _eh_sigspec_argc(method):
+    """Helper function to get the argument count of an event handler method."""
+    func = getattr(method, '__func__', method)
+    code = getattr(func, '__code__', None)
+    if code is None or getattr(func, '__signature__', None) is not None:
+        # not a plain function, or it advertises its own signature: ask inspect
+        return len(getfullargspec(method)[0])
+
+    # co_argcount counts self and excludes *args/**kwargs, like getfullargspec
+    return code.co_argcount
+
 def _eh_sigspec_invoke_compat(method, argc_legacy, *args):
     """
     Helper function to invoke an event handler method, with legacy
@@ -43,7 +54,7 @@ def _eh_sigspec_invoke_compat(method, argc_legacy, *args):
     This should be removed when old signatures (< 1.8) aren't supported
     anymore (in 2.x).
     """
-    argc_actual = len(getfullargspec(method)[0])
+    argc_actual = _eh_sigspec_argc(method)
     if argc_actual == argc_legacy:
         # Use legacy signature (1.x) deprecated as of 1.9
         warnings.warn("%s should use new %s() signature" % (method.__self__,
@@ -56,7 +67,7 @@ def _eh_sigspec_invoke_compat(method, argc_legacy, *args):
 
 def _eh_sigspec_ev_read_17(ev_read):
     """Helper function to check whether ev_read has the old 1.7 signature."""
-    if len(getfullargspec(ev_read)[0]) == 2:
+    if _eh_sigspec_argc(ev_read) == 2:
         warnings.warn("%s should use new ev_read() signature" % \
                       ev_read.__self__, DeprecationWarning)
         return True

--- a/tests/TaskEventTest.py
+++ b/tests/TaskEventTest.py
@@ -3,11 +3,13 @@
 
 """Unit test for ClusterShell Task (event-based mode)"""
 
+from inspect import Parameter, Signature
 import unittest
 import warnings
 
 from ClusterShell.Task import *
 from ClusterShell.Event import EventHandler
+from ClusterShell.Worker.Worker import _eh_sigspec_argc
 
 
 class BaseAssertTestHandler(EventHandler):
@@ -169,6 +171,43 @@ class TaskEventTest(unittest.TestCase):
         # warnings: pickup + read + hup + close
         self.run_task_and_catch_warnings(task, 4)
         eh.do_asserts_read_notimeout()
+
+    def test_mixed_event_handlers(self):
+        """test legacy and 1.8+ event handlers in the same task"""
+        task = task_self()
+
+        eh_legacy = LegacyTestHandler()
+        eh = TestHandler()
+        task.shell("echo abcdefghijklmnopqrstuvwxyz", handler=eh_legacy)
+        task.shell("echo abcdefghijklmnopqrstuvwxyz", handler=eh)
+        # warnings: pickup + read + hup + close (legacy handler only)
+        self.run_task_and_catch_warnings(task, 4)
+
+        eh_legacy.do_asserts_read_notimeout()
+        eh.do_asserts_read_notimeout()
+
+    def test_event_handler_instance_attribute(self):
+        """test event handler with ev_read set on the instance"""
+        task = task_self()
+
+        eh = TestHandler()
+        read = []
+        # not a bound method: no self argument
+        eh.ev_read = lambda worker, node, sname, msg: read.append(msg)
+        task.shell("echo abcdefghijklmnopqrstuvwxyz", handler=eh)
+        self.run_task_and_catch_warnings(task)
+
+        self.assertEqual(read, [b"abcdefghijklmnopqrstuvwxyz"])
+
+    def test_eh_sigspec_explicit_signature(self):
+        """test signature check with an explicit __signature__ (eg. wrapt)"""
+        def ev_read(*args, **kwargs):
+            pass
+
+        ev_read.__signature__ = Signature([Parameter(name,
+                                                     Parameter.POSITIONAL_OR_KEYWORD)
+                                           for name in ('self', 'worker')])
+        self.assertEqual(_eh_sigspec_argc(ev_read), 2)
 
     def test_simple_event_handler(self):
         """test simple event handler (1.8+)"""


### PR DESCRIPTION
The 1.7-signature compatibility shims call `inspect.getfullargspec()` on every event — once per output line for `ev_read`, and once per pickup/hup/close for the other helper. On Python 3 that builds a full `Signature` object (~11 µs); Python 2's `getargspec()` read the code object directly, so this cost appeared silently when the py3 import fallback was introduced.

Everyone pays it, not just users of the deprecated signature: the check is what answers "is this handler legacy?", so it runs before we know, for every handler, on every line.

`_eh_sigspec_argc()` now reads the argument count from the code object, falling back to `getfullargspec()` for anything that is not a plain function or that advertises its own `__signature__` — the only two cases where the two can disagree, so the verdict is unchanged by construction.

Measured before → after, local worker, 200 000 lines, medians of 3:

| | python 3.13 | python 3.9 (EL9) | python 3.6 (EL8) |
|---|---|---|---|
| `_on_node_msgline()`, isolated | 13.58 → 1.67 µs/line (**8.1x**) | 18.17 → 3.03 µs/line (**6.0x**) | 20.75 → 3.96 µs/line (**5.2x**) |
| 200k lines, 1.8+ handler | 3068 → 457 ms (**6.7x**) | 4261 → 912 ms (**4.7x**) | 4512 → 1010 ms (**4.5x**) |
| 200k lines, legacy handler | 2671 → 686 ms (3.9x) | 3538 → 1195 ms (3.0x) | 3841 → 1301 ms (3.0x) |
| 200k lines, no handler | 372–390 → 369–393 ms (1.0x) | 774–789 → 778–788 ms (1.0x) | 804–843 → 803–827 ms (1.0x) |
| `clush -R exec -b -w n[1-100] seq 1 100` | 0.390 → 0.249 s (1.6x) | 0.541 → 0.334 s (1.6x) | 0.603 → 0.380 s (1.6x) |

The relative gain shrinks on older interpreters because the rest of the dispatch path is slower there too; the absolute saving per line grows (13.1 → 16.7 → 17.5 µs).

- No API or behavior change: `DeprecationWarning`s still fire per event and existing legacy-signature tests pass unmodified. The legacy path keeps ~1.2 µs/line of `warnings.warn()`, which is why it gains less.
- The no-handler row is a control: the engine path that never reaches the check is unaffected.
- Tests added for mixed legacy/1.8+ handlers, `ev_read` set on the instance, and the `__signature__` fallback.
- Temporary by design: dropping pre-1.8 signature support in 2.0 removes both helpers and the per-line check entirely.
