### PR TITLE
EngineClient: speed up write buffer drain

### DIFF
--- a/lib/ClusterShell/Worker/EngineClient.py
+++ b/lib/ClusterShell/Worker/EngineClient.py
@@ -81,6 +81,7 @@ class EngineClientStream(object):
         self.fd = None
         self.rbuf = bytes()
         self.wbuf = bytes()
+        self.woff = 0
         self.eof = False
         self.evmask = evmask
         self.events = 0
@@ -111,7 +112,8 @@ class EngineClientStream(object):
     def __repr__(self):
         return "<%s at 0x%s (name=%s fd=%s rbuflen=%d wbuflen=%d eof=%d " \
             "evmask=0x%x)>" % (self.__class__.__name__, id(self), self.name,
-            self.fd, len(self.rbuf), len(self.wbuf), self.eof, self.evmask)
+            self.fd, len(self.rbuf), len(self.wbuf) - self.woff, self.eof,
+            self.evmask)
 
     def close(self):
         """Close stream."""
@@ -328,8 +330,14 @@ class EngineClient(EngineBaseTimer):
             if self._engine:
                 self._engine.remove_stream(self, wfile)
         elif len(wfile.wbuf) > 0:
+            woff = wfile.woff
+            if woff:
+                # zero-copy view from drain offset (avoids quadratic re-slice)
+                wbuf = memoryview(wfile.wbuf)[woff:]
+            else:
+                wbuf = wfile.wbuf
             try:
-                wcnt = os.write(wfile.fd, wfile.wbuf)
+                wcnt = os.write(wfile.fd, wbuf)
             except OSError as exc:
                 if exc.errno == errno.EAGAIN:
                     # _handle_write() is not only called by the engine but also
@@ -345,8 +353,12 @@ class EngineClient(EngineBaseTimer):
                     return
                 raise
             if wcnt > 0:
-                # dequeue written buffer
-                wfile.wbuf = wfile.wbuf[wcnt:]
+                # dequeue written bytes
+                if wcnt == len(wbuf):
+                    wfile.wbuf = bytes()
+                    wfile.woff = 0
+                else:
+                    wfile.woff = woff + wcnt
                 # check for possible ending
                 if wfile.eof and not wfile.wbuf:
                     self.worker._on_written(self.key, wcnt, sname)
@@ -419,13 +431,15 @@ class EngineClient(EngineBaseTimer):
             return
 
         wfile = self.streams[sname]
+        if wfile.woff:
+            # compact already-written prefix before appending
+            wfile.wbuf = wfile.wbuf[wfile.woff:]
+            wfile.woff = 0
+
+        wfile.wbuf += buf
         if self._engine and wfile.fd:
-            wfile.wbuf += buf
             # give it a try now (will set writing flag anyhow)
             self._handle_write(sname)
-        else:
-            # bufferize until pipe is ready
-            wfile.wbuf += buf
 
     def _set_write_eof(self, sname):
         """Set EOF on specific writable stream."""

--- a/tests/TaskLocalMixin.py
+++ b/tests/TaskLocalMixin.py
@@ -422,6 +422,42 @@ class TaskLocalMixin(object):
         # read result
         self.assertEqual(worker.read(), b"cracoucasse")
 
+    def testLocalWorkerWritesLarge(self):
+        # write far exceeding pipe capacity to get engine-driven partial writes
+        task = task_self()
+        worker = task.shell("cat")
+        data = b''.join(b'%07d padding padding\n' % i for i in range(80000))
+        worker.write(data)
+        worker.set_write_eof()
+        task.resume()
+        self.assertEqual(worker.read(), data[:-1])
+
+    def testLocalWorkerWritesFromEvWritten(self):
+        # queue more data from ev_written while a drain is in progress
+        class ChunkWriter(EventHandler):
+            def __init__(self, chunks):
+                self.chunks = chunks
+                self.nextidx = 1
+                self.eof_sent = False
+
+            def ev_written(self, worker, node, sname, size):
+                # ev_written fires again from within write(): bump index first
+                if self.nextidx < len(self.chunks):
+                    nextidx = self.nextidx
+                    self.nextidx += 1
+                    worker.write(self.chunks[nextidx])
+                elif not self.eof_sent:
+                    self.eof_sent = True
+                    worker.set_write_eof()
+
+        task = task_self()
+        # chunks larger than pipe capacity so eof is set while data is pending
+        chunks = [(b'%063d\n' % i) * 4096 for i in range(8)]
+        worker = task.shell("cat", handler=ChunkWriter(chunks))
+        worker.write(chunks[0])
+        task.resume()
+        self.assertEqual(worker.read(), b''.join(chunks)[:-1])
+
     def testEscape(self):
         task = task_self()
         worker = task.shell(r"export CSTEST=foobar; /bin/echo \$CSTEST | sed 's/\ foo/bar/'")


### PR DESCRIPTION
`EngineClient._handle_write()` dequeued written bytes with `wfile.wbuf = wfile.wbuf[wcnt:]`, copying the whole unwritten remainder after every pipe write (≤64 KB) — a quadratic (O(n²)) total memcpy for n bytes pushed through a worker's stdin. This slows down `clush --copy` (tar streamed through stdin), `cat big_file | clush`, rcopy, and gateway channel writes, with throughput decaying as the buffer grows.

The write buffer is now immutable while draining: a new stream offset (`woff`) tracks already-written bytes and `os.write()` receives `memoryview(wbuf)[woff:]` (zero-copy). When no drain is in progress (`woff == 0`) — the common case of a write fully drained in one call — `os.write()` receives `wbuf` exactly as before. `_write()` compacts the written prefix before appending, so appends stay linear and long-lived streams (gateway channels) release written memory promptly. One behavioral note: a single large write now stays fully resident until completely drained, where the old per-write slicing progressively released the written prefix; peak usage is comparable (each old slice transiently held buffer + remainder) and the caller typically still holds the buffer anyway.

Drain throughput (one-shot buffer through a worker stdin pipe, best-of-3):

| Size | before | after | speedup |
|------|--------|-------|---------|
| 4 MB | 13.2 ms (303 MB/s) | 1.1 ms (3569 MB/s) | 12x |
| 8 MB | 34.4 ms (233 MB/s) | 2.4 ms (3301 MB/s) | 14x |
| 16 MB | 124.9 ms (128 MB/s) | 4.7 ms (3371 MB/s) | 27x |
| 32 MB | 492.3 ms (65 MB/s) | 8.9 ms (3588 MB/s) | 55x |

- End-to-end `task.shell("cat > /dev/null")` + 32 MB write: 508 → 16 ms (31.6x) on py3.13; 539 → 22 ms (24.8x) on py3.9/EL9. At 64 MB, before-times collapse further (allocator pressure): 12.9 s → 29.5 ms.
- `_handle_write` benchmarked in isolation on the common small fully-drained write: no measurable change (within run-to-run noise on py3.13; 2.07 → 2.07 µs on py3.9).
- Data integrity checked by md5 round-trip of 8 MB through `md5sum`.
- memoryview drain path verified at runtime on Python 2.7.5 (CentOS 7): 32 MB drain 762 → 10 ms, byte-exact output.

New tests write a large buffer through `cat` and verify the exact round-trip, both as a single write and with more data appended from `ev_written` mid-drain.
