### PR TITLE
cluset: fix parsing of last stdin line without newline

### DIFF
--- a/lib/ClusterShell/CLI/Nodeset.py
+++ b/lib/ClusterShell/CLI/Nodeset.py
@@ -48,7 +48,7 @@ def process_stdin(xsetop, xsetcls, autostep):
     tmpset = xsetcls(autostep=autostep)
     for line in sys.stdin:  # read lines of text stream (not bytes)
         # Support multi-lines and multi-nodesets per line
-        line = line[0:line.find('#')].strip()
+        line = line.split('#', 1)[0].strip()
         for elem in line.split():
             # Do explicit object creation for RangeSet
             tmpset.update(xsetcls(elem, autostep=autostep))

--- a/tests/CLINodesetTest.py
+++ b/tests/CLINodesetTest.py
@@ -336,6 +336,10 @@ class CLINodesetTest(CLINodesetTestBase):
         """test nodeset - (stdin)"""
         self._nodeset_t(["-f", "-"], "foo\n", b"foo\n")
         self._nodeset_t(["-f", "-"], "foo1 foo2 foo3\n", b"foo[1-3]\n")
+        self._nodeset_t(["-f", "-"], "foo5", b"foo5\n")
+        self._nodeset_t(["-f", "-"], "foo[1-2]", b"foo[1-2]\n")
+        self._nodeset_t(["-f", "-"], "# comment\nfoo\n", b"foo\n")
+        self._nodeset_t(["-f", "-"], "foo1 foo2 # comment\n", b"foo[1-2]\n")
         self._nodeset_t(["--autostep=2", "-f"], "foo0 foo2 foo4 foo6\n", b"foo[0-6/2]\n")
         self._nodeset_t(["--autostep=auto", "-f"], "foo0 foo2 foo4 foo6\n", b"foo[0-6/2]\n")
         self._nodeset_t(["--autostep=100%", "-f"], "foo0 foo2 foo4 foo6\n", b"foo[0-6/2]\n")


### PR DESCRIPTION
`cluset -f -` silently drops the last character when the final stdin line has no trailing newline: `printf 'node5' | cluset -f -` returns `node`, and `printf 'node[1-2]' | cluset -f -` fails with a parse error.

Cause: `line[0:line.find('#')]` in `process_stdin()` evaluates to `line[0:-1]` when a line contains no `#`, which relied on the trailing newline to be harmless. Use `line.split('#', 1)[0]` instead — same comment-stripping semantics, newline-independent.

Adds stdin tests for an unterminated last line and for `#` comment handling (previously untested).

See #694
