### PR TITLE
clush: ignore '#' comments in --hostfile

### DIFF
--- a/doc/man/man1/cluset.1
+++ b/doc/man/man1/cluset.1
@@ -159,7 +159,8 @@ pick N node(s) at random in nodeset
 For a short explanation of these options, see \fB\-h, \-\-help\fP\&.
 .sp
 If a single hyphen\-minus (\-) is given as a nodeset, it will be read from
-standard input.
+standard input. Text from a \fB#\fP to the end of a line is ignored, as are
+empty lines.
 .SH EXTENDED PATTERNS
 .sp
 The \fBcluset\fP command benefits from ClusterShell NodeSet basic

--- a/doc/man/man1/clush.1
+++ b/doc/man/man1/clush.1
@@ -201,7 +201,7 @@ run command on a group of nodes
 exclude nodes from this group
 .TP
 .BI \-\-hostfile\fB= FILE\fR,\fB \ \-\-machinefile\fB= FILE
-path to a file containing a list of single hosts, node sets or node groups, separated by spaces and lines (may be specified multiple times, one per file)
+path to a file containing a list of single hosts, node sets or node groups, separated by spaces and lines; text from a \fB#\fP to the end of a line is ignored, as are empty lines (may be specified multiple times, one per file)
 .TP
 .BI \-\-topology\fB= FILE
 topology configuration file to use for tree mode

--- a/doc/man/man1/nodeset.1
+++ b/doc/man/man1/nodeset.1
@@ -159,7 +159,8 @@ pick N node(s) at random in nodeset
 For a short explanation of these options, see \fB\-h, \-\-help\fP\&.
 .sp
 If a single hyphen\-minus (\-) is given as a nodeset, it will be read from
-standard input.
+standard input. Text from a \fB#\fP to the end of a line is ignored, as are
+empty lines.
 .SH EXTENDED PATTERNS
 .sp
 The \fBnodeset\fP command benefits from ClusterShell NodeSet basic

--- a/doc/sphinx/tools/cluset.rst
+++ b/doc/sphinx/tools/cluset.rst
@@ -97,7 +97,8 @@ The following example illustrates the three ways to feed *cluset*::
 
 
 Furthermore, *cluset*'s standard input reader is able to process multiple
-lines and multiple node sets or groups per line. The following example shows a
+lines and multiple node sets or groups per line. Text from a ``#`` to the end
+of a line is ignored, as are empty lines. The following example shows a
 simple use case::
 
     $ mount -t nfs | cut -d':' -f1

--- a/doc/sphinx/tools/clush.rst
+++ b/doc/sphinx/tools/clush.rst
@@ -104,7 +104,8 @@ Host files
 
 The option ``--hostfile`` (or ``--machinefile``) may be used to specify a
 path to a file containing a list of single hosts, node sets or node groups,
-separated by spaces and lines.  It may be specified multiple times (one per
+separated by spaces and lines.  Text from a ``#`` to the end of a line is
+ignored, as are empty lines.  It may be specified multiple times (one per
 file).
 
 For example::

--- a/doc/sphinx/tools/nodeset.rst
+++ b/doc/sphinx/tools/nodeset.rst
@@ -96,7 +96,8 @@ The following example illustrates the three ways to feed *nodeset*::
 
 
 Furthermore, *nodeset*'s standard input reader is able to process multiple
-lines and multiple node sets or groups per line. The following example shows a
+lines and multiple node sets or groups per line. Text from a ``#`` to the end
+of a line is ignored, as are empty lines. The following example shows a
 simple use case::
 
     $ mount -t nfs | cut -d':' -f1

--- a/doc/txt/cluset.txt
+++ b/doc/txt/cluset.txt
@@ -87,7 +87,8 @@ OPTIONS
 For a short explanation of these options, see ``-h, --help``.
 
 If a single hyphen-minus (-) is given as a nodeset, it will be read from
-standard input.
+standard input. Text from a ``#`` to the end of a line is ignored, as are
+empty lines.
 
 EXTENDED PATTERNS
 =================

--- a/doc/txt/clush.txt
+++ b/doc/txt/clush.txt
@@ -153,7 +153,7 @@ Selecting target nodes:
                       run command on a group of nodes
   -X GROUP            exclude nodes from this group
   --hostfile=FILE, --machinefile=FILE
-                      path to a file containing a list of single hosts, node sets or node groups, separated by spaces and lines (may be specified multiple times, one per file)
+                      path to a file containing a list of single hosts, node sets or node groups, separated by spaces and lines; text from a ``#`` to the end of a line is ignored, as are empty lines (may be specified multiple times, one per file)
   --topology=FILE     topology configuration file to use for tree mode
   --pick=N            pick N node(s) at random in nodeset
 

--- a/doc/txt/nodeset.txt
+++ b/doc/txt/nodeset.txt
@@ -87,7 +87,8 @@ OPTIONS
 For a short explanation of these options, see ``-h, --help``.
 
 If a single hyphen-minus (-) is given as a nodeset, it will be read from
-standard input.
+standard input. Text from a ``#`` to the end of a line is ignored, as are
+empty lines.
 
 EXTENDED PATTERNS
 =================

--- a/lib/ClusterShell/CLI/Clush.py
+++ b/lib/ClusterShell/CLI/Clush.py
@@ -926,7 +926,9 @@ def main():
         try:
             fnodeset = NodeSet()
             with open(opt_hostfile) as hostfile:
-                for line in hostfile.read().splitlines():
+                for line in hostfile:
+                    # Support multi-nodesets per line and '#' comments
+                    line = line.split('#', 1)[0].strip()
                     fnodeset.updaten(nodes for nodes in line.split())
             display.vprint_err(VERB_DEBUG,
                                "Using nodeset %s from hostfile %s"

--- a/tests/CLIClushTest.py
+++ b/tests/CLIClushTest.py
@@ -482,6 +482,10 @@ class CLIClushTest_A(unittest.TestCase):
         f2 = make_temp_file(HOSTNAME.encode())
         self._clush_t(["--hostfile", f.name, "--hostfile", f2.name,
                        "echo", "ok"], None, self.output_ok)
+        f3 = make_temp_file(b"# comment\ncs[01-02] # inline comment\n\ncs03\n")
+        self._clush_t(["--worker=exec", "--hostfile", f3.name, "-b", "echo",
+                       "ok"], None,
+                      b'---------------\ncs[01-03] (3)\n---------------\nok\n')
         self.assertRaises(OSError, self._clush_t,
                           ["--hostfile", "/I/do/NOT/exist", "echo", "ok"],
                           None, 1)


### PR DESCRIPTION
`--hostfile` does no `#` comment handling, unlike `cluset`/`nodeset` reading from stdin: comment words become SSH targets (`# managed by ansible` → clush targets `#`, `managed`, `by`, `ansible`), rangeset-like comment text expands to bogus hosts, and an unbalanced bracket in a comment aborts clush with a parse error.

`--hostfile` was added for pdsh compatibility (#235), and pdsh strips `#` comments in WCOLL files; so do pssh, OpenMPI `--hostfile` and GNU parallel `--sshloginfile`. Strip text from a `#` to the end of the line, same semantics as `cluset` stdin and pdsh.

Also documents the host file format and the previously undocumented stdin comment support in the nodeset/cluset docs (man pages regenerated with docutils 0.20.1).

Closes #694
