### PR TITLE
NodeSet: speed up regroup() with per-group intersection

### DIFF
--- a/lib/ClusterShell/NodeSet.py
+++ b/lib/ClusterShell/NodeSet.py
@@ -1412,21 +1412,14 @@ class NodeSet(NodeSetBase):
 
     __copy__ = copy # For the copy module
 
-    def _find_groups(self, node, namespace, allgroups):
-        """Find groups of node by namespace."""
-        if allgroups:
-            # find node groups using in-memory allgroups
-            for grp, nodeset in allgroups.items():
-                if node in nodeset:
-                    yield grp
-        else:
-            # find node groups using resolver
-            try:
-                for group in self._resolver.node_groups(node, namespace):
-                    yield group
-            except NodeUtils.GroupSourceQueryFailed as exc:
-                msg = "Group source query failed: %s" % exc
-                raise NodeSetExternalError(msg)
+    def _find_groups(self, node, namespace):
+        """Find groups of node by namespace, using external reverse."""
+        try:
+            for group in self._resolver.node_groups(node, namespace):
+                yield group
+        except NodeUtils.GroupSourceQueryFailed as exc:
+            msg = "Group source query failed: %s" % exc
+            raise NodeSetExternalError(msg)
 
     def _groups2(self, groupsource=None, autostep=None):
         """Find node groups this nodeset belongs to. [private]"""
@@ -1454,23 +1447,35 @@ class NodeSet(NodeSetBase):
             try:
                 # use internal reverse: populate allgroups
                 for grp in allgrplist:
-                    nodelist = self._resolver.group_nodes(grp, groupsource)
-                    allgroups[grp] = NodeSet(",".join(nodelist),
-                                             resolver=self._resolver)
+                    allgroups[grp] = self._parser.parse_group(grp, groupsource,
+                                                              autostep)
             except NodeUtils.GroupSourceQueryFailed as exc:
                 # External result inconsistency
                 raise NodeSetExternalError("Unable to map a group " \
                         "previously listed\n\tFailed command: %s" % exc)
 
-        # For each NodeSetBase in self, find its groups.
-        for node in self._iterbase():
-            for grp in self._find_groups(node, groupsource, allgroups):
-                if grp not in groups_info:
-                    nodes = self._parser.parse_group(grp, groupsource, autostep)
-                    groups_info[grp] = (1, nodes)
+        if allgroups:
+            # For each group, count the nodes of self it contains.
+            selflen = len(self)
+            for grp, nodes in allgroups.items():
+                # intersection() copies its left operand: use the smaller one
+                if selflen < len(nodes):
+                    cnt = len(self.intersection(nodes))
                 else:
-                    i, nodes = groups_info[grp]
-                    groups_info[grp] = (i + 1, nodes)
+                    cnt = len(nodes.intersection(self))
+                if cnt > 0:
+                    groups_info[grp] = (cnt, nodes)
+        else:
+            # For each NodeSetBase in self, find its groups.
+            for node in self._iterbase():
+                for grp in self._find_groups(node, groupsource):
+                    if grp not in groups_info:
+                        nodes = self._parser.parse_group(grp, groupsource,
+                                                         autostep)
+                        groups_info[grp] = (1, nodes)
+                    else:
+                        i, nodes = groups_info[grp]
+                        groups_info[grp] = (i + 1, nodes)
         return groups_info
 
     def groups(self, groupsource=None, noprefix=False):


### PR DESCRIPTION
`NodeSet._groups2()` looked for the groups of each node, testing every node of the nodeset against every group of the source: `|nodeset| × |groups|` membership tests, plus a second parse of every matching group. It now counts the nodes of the nodeset contained in each group, with one intersection per group.

- `intersection()` copies its left operand, so the smaller of the two sets is used as the receiver: always starting from the nodeset is up to 50x slower on large sets, and the reverse holds for tiny ones
- group node sets are built with `parse_group()` and reused, so each group of the source is parsed once instead of once plus once per match
- the external reverse path (sources with a `reverse` upcall) is unchanged

Measured with an in-memory group source, best of 3 interleaved runs:

| case | before | after |
| --- | --- | --- |
| `regroup()`, 500 groups × 200 nodes, 1000 nodes | 418 ms | 54 ms |
| `regroup()`, 2000 groups × 50 nodes, 5000 nodes | 9005 ms | 120 ms |
| `regroup()`, 500 groups × 200 nodes, 20000 nodes | 8521 ms | 58 ms |
| `groups()`, 500 groups × 200 nodes, 20000 nodes | 8382 ms | 188 ms |
| `regroup()`, group lists expanded node by node, 1000 nodes | 1230 ms | 876 ms |
| `regroup()` of a single node, 500 groups × 200 nodes | 48.6 ms | 43.9 ms |

The last line is the case that could have regressed: one intersection costs more than one membership test, so a plain loop inversion is ~18% slower for node sets below about 4 nodes, which is what `clush -b -r` does when output blocks hold a single node. Reusing the parsed group node sets pays for that; per-block timings of the `clush -b -r` pattern are 1.0x to 1.8x better. The expanded-group-list line is bound by parsing all groups of the source, which both versions do.

As a side effect, a source `map` upcall is now run once per group instead of once per group plus once per matching group.
