### PR TITLE
RangeSetND: fix autostep loss in copy() and binary operations

### DIFF
--- a/lib/ClusterShell/RangeSet.py
+++ b/lib/ClusterShell/RangeSet.py
@@ -999,6 +999,8 @@ class RangeSetND(object):
     def copy(self):
         """Return a new, mutable shallow copy of a RangeSetND."""
         cpy = self.__class__()
+        cpy._autostep = self._autostep
+
         # Shallow "to the extent possible" says the copy module, so here that
         # means calling copy() on each sub-RangeSet to keep mutability.
         cpy._veclist = [[rg.copy() for rg in rgvec] for rgvec in self._veclist]
@@ -1528,7 +1530,7 @@ class RangeSetND(object):
         if other is self:
             return
 
-        tmp_rnd = RangeSetND()
+        tmp_rnd = RangeSetND(autostep=self.autostep)
 
         empty_rset = RangeSet()
 

--- a/tests/RangeSetNDTest.py
+++ b/tests/RangeSetNDTest.py
@@ -212,6 +212,34 @@ class RangeSetNDTest(unittest.TestCase):
                       ["0", "3", "5"], ["0", "1", "4"], ["0", "2", "4"],
                       ["2", "1", "4"]], folded, 13)
 
+    def test_autostep(self):
+        rn1 = RangeSetND([["0-10/2", "1-3"]], autostep=2)
+        rn2 = RangeSetND([["20-30/2", "1-3"]], autostep=2)
+        # autostep is preserved by copy()
+        self.assertEqual(rn1.copy().autostep, 2)
+        self.assertEqual(str(rn1.copy()), "0-10/2; 1-3\n")
+        # autostep is preserved by binary operations
+        for rnres in (rn1 | rn2, rn1.union(rn2), rn1 - rn2, rn1 & rn2,
+                      rn1 ^ rn2):
+            self.assertEqual(rnres.autostep, 2)
+        rnu = rn1 | rn2
+        self.assertEqual(str(rnu), "0-10/2,20-30/2; 1-3\n")
+        # multivariate results keep autostep too (axes are rebuilt on fold)
+        rnm = rn1 | RangeSetND([["20-30/2", "5-7"]], autostep=2)
+        self.assertEqual(str(rnm), "0-10/2; 1-3\n20-30/2; 5-7\n")
+        # str() is a fixed point: container and axes agree on autostep
+        self.assertEqual(str(RangeSetND([["0-10/2,20-30/2", "1-3"]],
+                                        autostep=2)), str(rnu))
+        # left operand's autostep wins
+        rn3 = RangeSetND([["40-50", "1-3"]])
+        self.assertEqual((rn1 | rn3).autostep, 2)
+        self.assertEqual((rn3 | rn1).autostep, None)
+        # intersection_update() also keeps axis autostep
+        rni = RangeSetND([["0-10/2", "1-3"]], autostep=2)
+        rni.intersection_update(RangeSetND([["0-10/2", "1-3"]]))
+        self.assertEqual(rni.autostep, 2)
+        self.assertEqual(str(rni), "0-10/2; 1-3\n")
+
     def test_union(self):
         rn1 = RangeSetND([["10-100", "1-3"], ["1100-1300", "2-3"]])
         self.assertEqual(str(rn1), "1100-1300; 2-3\n10-100; 1-3\n")


### PR DESCRIPTION
Fix `RangeSetND` losing `autostep` (found while stress-testing #656, companion of #692):

- `copy()` now carries `autostep` over, like `RangeSet.copy()`. The non-in-place binary operations (`|`, `-`, `&`, `^` and method forms) build on `copy()`, so they now inherit the left operand's autostep, matching `RangeSet`.
- `intersection_update()` now keeps axis autostep (its internal temporary reset it).

Before/after:

```console
$ nodeset --autostep=2 -f "n[0-10/2]p[1-3]" -i "n[0-10/2]p[1-3]"
n[0,2,4,6,8,10]p[1-3]    # before
n[0-10/2]p[1-3]          # after
```

The CLI change is limited to `-i` (other nodeset/cluset operations use the in-place methods and are unchanged). For library users, non-in-place results on nD sets now render with step notation when the left operand has autostep — rendering only, element contents verified unchanged by differential fuzzing. No measurable perf change in isolated benchmarks of both methods.

Closes #700